### PR TITLE
Creates file when does not exist for put_contents().

### DIFF
--- a/Tests/Unit/VirtualFilesystemDirect/putContents.php
+++ b/Tests/Unit/VirtualFilesystemDirect/putContents.php
@@ -22,8 +22,30 @@ class Test_PutContents extends TestCase {
 		$this->assertSame( $content, $this->filesystem->get_contents( 'Tests/Unit/SomeClass/getFile.php' ) );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
-		$this->assertFalse( $this->filesystem->put_contents( 'baz/invalid.html', 'New contents' ) );
-		$this->assertFalse( $this->filesystem->put_contents( 'cache/Tests/Unit/invalid.php', 'New contents' ) );
+	function testShouldCreateFileAndPutContentsWhenFileDoesNotExist() {
+		$data = [
+			'baz/newfile.html' => 'Lorem ipsum dolor sit amet',
+			'cache/Tests/Unit/SomeClass/putContents.php' => 'Praesent a nibh in nulla dapibus gravida.',
+		];
+		foreach( $data as $filename => $content ) {
+			$this->assertFalse( $this->filesystem->exists( $filename ) );
+			$this->assertTrue( $this->filesystem->put_contents( $filename, $content ) );
+			$this->assertTrue( $this->filesystem->exists( $filename ) );
+			$this->assertSame( $content, $this->filesystem->get_contents( $filename ) );
+		}
+
+		// Test with fopen() just to be sure.
+		$filename = 'cache/Tests/Unit/SomeClass/createNewFile.php';
+		$this->assertFalse( $this->filesystem->exists( $filename ) );
+		$fp = @fopen( $this->filesystem->getUrl( $filename ), 'wb' );
+		if ( $fp ) {
+			fclose( $fp );
+		}
+		// Yes, it created the new virtual file.
+		$this->assertTrue( $this->filesystem->exists( $filename ) );
+		// Yes, it adds the content to the new file.
+		$contents = 'Praesent a nibh in nulla dapibus gravida.';
+		$this->assertTrue( $this->filesystem->put_contents( $filename, $contents ) );
+		$this->assertSame( $contents, $this->filesystem->get_contents( $filename ) );
 	}
 }

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -153,7 +153,7 @@ class VirtualFilesystemDirect {
 	 * @return bool True on success, false on failure.
 	 */
 	public function put_contents( $filename, $contents, $mode = false ) {
-		$file = $this->getFile( $filename );
+		$file = $this->getOrCreateFile( $filename );
 		if ( is_null( $file ) ) {
 			return false;
 		}
@@ -164,6 +164,32 @@ class VirtualFilesystemDirect {
 		$this->chmod( $filename, $mode );
 
 		return true;
+	}
+
+	/**
+	 * Get file. If doesn't exist, creates it and then returns it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $filename Absolute path to file.
+	 *
+	 * @return bool|vfsStreamFile file on success; false on failure.
+	 */
+	protected function getOrCreateFile( $filename ) {
+		$filename = $this->prefixRoot( $filename );
+
+		// If the file exists, return it.
+		if ( $this->is_file( $filename ) ) {
+			return $this->getFile( $filename );
+		}
+
+		// Attempt to create the file. If it fails, return false.
+		if ( ! $this->touch( $filename ) ) {
+			return false;
+		}
+
+		// Created it. Get and return the file.
+		return $this->getFile( $filename );
 	}
 
 	/**
@@ -382,6 +408,7 @@ class VirtualFilesystemDirect {
 		if ( $atime == 0 ) {
 			$atime = time();
 		}
+
 		return touch( $this->getUrl( $file ), $time, $atime );
 	}
 


### PR DESCRIPTION
`WP_Filesystem_Direct::put_contents()` uses `@fopen()`. That means it will create the file if it doesn't exist. 

```php
	/**
	 * Writes a string to a file.
	 *
	 * @since 2.5.0
	 *
	 * @param string    $file     Remote path to the file where to write the data.
	 * @param string    $contents The data to write.
	 * @param int|false $mode     Optional. The file permissions as octal number, usually 0644.
	 *                            Default false.
	 * @return bool True on success, false on failure.
	 */
	public function put_contents( $file, $contents, $mode = false ) {
		$fp = @fopen( $file, 'wb' );
		if ( ! $fp ) {
			return false;
		}

		mbstring_binary_safe_encoding();

		$data_length = strlen( $contents );

		$bytes_written = fwrite( $fp, $contents );

		reset_mbstring_encoding();

		fclose( $fp );

		if ( $data_length !== $bytes_written ) {
			return false;
		}

		$this->chmod( $file, $mode );

		return true;
	}
```

This PR uses the `touch()` method to create the file when invoking `put_contents()`.