### PR TITLE
Adds property for URL to the root virtual directory.

### DIFF
--- a/Integration/VirtualFilesystemTestCase.php
+++ b/Integration/VirtualFilesystemTestCase.php
@@ -45,11 +45,19 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $filesystem;
 
 	/**
+	 * URL to the root directory of the virtual filesystem.
+	 *
+	 * @var string
+	 */
+	protected $rootVirtualUrl;
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	public function setUp() {
 		parent::setUp();
 
-		$this->filesystem = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
+		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
+		$this->rootVirtualUrl = $this->filesystem->getUrl( $this->rootVirtualDir );
 	}
 }

--- a/Unit/VirtualFilesystemTestCase.php
+++ b/Unit/VirtualFilesystemTestCase.php
@@ -45,11 +45,19 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $filesystem;
 
 	/**
+	 * URL to the root directory of the virtual filesystem.
+	 *
+	 * @var string
+	 */
+	protected $rootVirtualUrl;
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	protected function setUp() {
 		parent::setUp();
 
-		$this->filesystem = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
+		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
+		$this->rootVirtualUrl = $this->filesystem->getUrl( $this->rootVirtualDir );
 	}
 }


### PR DESCRIPTION
Adds `$rootVirtualUrl` property to the unit and integration `VirtualFilesystemTestCase`, making it available for use in a child test case and test classes. It's automatically assigned during `setUp()`. 