### PR TITLE
Changes from self to static to allow child class to overload.

### DIFF
--- a/Unit/TestCase.php
+++ b/Unit/TestCase.php
@@ -32,8 +32,8 @@ abstract class TestCase extends PHPUnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		if ( self::$stubPolyfills ) {
-			self::stubPolyfills();
+		if ( static::$stubPolyfills ) {
+			static::stubPolyfills();
 		}
 	}
 
@@ -44,7 +44,7 @@ abstract class TestCase extends PHPUnitTestCase {
 		parent::setUp();
 		Monkey\setUp();
 
-		if ( self::$mockCommonWpFunctionsInSetUp ) {
+		if ( static::$mockCommonWpFunctionsInSetUp ) {
 			$this->mockCommonWpFunctions();
 		}
 	}


### PR DESCRIPTION
In order for the child classes to overload the static properties, the usage of them in the base `TestCase` must use `static` instead of `self`.