### PR TITLE
Basic callbacks

### DIFF
--- a/Integration/TestCase.php
+++ b/Integration/TestCase.php
@@ -26,4 +26,24 @@ abstract class TestCase extends WP_UnitTestCase {
 		Monkey\tearDown();
 		parent::tearDown();
 	}
+
+	public function return_0() {
+		return 0;
+	}
+
+	public function return_1() {
+		return 1;
+	}
+
+	public function return_false() {
+		return false;
+	}
+
+	public function return_true() {
+		return true;
+	}
+
+	public function return_empty_array() {
+		return [];
+	}
 }

--- a/Integration/phpunit.xml.dist
+++ b/Integration/phpunit.xml.dist
@@ -19,4 +19,9 @@
 			<exclude>../../../../Tests/Integration/bootstrap.php</exclude>
 		</testsuite>
 	</testsuites>
+	<groups>
+		<exclude>
+			<group>Exclude</group>
+		</exclude>
+	</groups>
 </phpunit>

--- a/Unit/phpunit.xml.dist
+++ b/Unit/phpunit.xml.dist
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-         bootstrap="bootstrap.php"
-         backupGlobals="false"
-         colors="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         verbose="true">
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+		 bootstrap="bootstrap.php"
+		 backupGlobals="false"
+		 colors="true"
+		 beStrictAboutCoversAnnotation="true"
+		 beStrictAboutOutputDuringTests="true"
+		 beStrictAboutTestsThatDoNotTestAnything="true"
+		 beStrictAboutTodoAnnotatedTests="true"
+		 convertErrorsToExceptions="true"
+		 convertNoticesToExceptions="true"
+		 convertWarningsToExceptions="true"
+		 verbose="true">
 
-    <testsuites>
-        <testsuite name="unit">
-            <directory suffix=".php">../../../../Tests/Unit/</directory>
+	<testsuites>
+		<testsuite name="unit">
+			<directory suffix=".php">../../../../Tests/Unit/</directory>
 			<exclude>../../../../Tests/Unit/bootstrap.php</exclude>
-        </testsuite>
-    </testsuites>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>Exclude</group>
+		</exclude>
+	</groups>
 </phpunit>


### PR DESCRIPTION
This adds simple methods to `Integration\TestCase`. They are like WordPress’ `__return_false()` and its friends, for the same purpose: hook callbacks during our tests.
So then why create these instead of using WordPress’ ones?
```php
add_filter( 'rocket_do_something', '__return_false' );
// Something to test...
remove_filter( 'rocket_do_something', '__return_false' );
```
Because when doing this, we may remove a `__return_false()` that could have been added externally by the plugin itself or something else. So by using our own methods we prevent changing the initial behavior.

Also in this PR:
I added a way to exclude tests from being processed by phpunit. It is as easy as adding a group to a method:
```php
class CustomTestCase extends TestCase {
	/**
	 * @group Exclude
	 */
	public function testFoobar() {
		// Prevent a warning. This should not run.
		$this->assertTrue( true );
	}
}
```
As you probably guessed, the magic word is `Exclude`.
Note: unfortunately that doesn't seem to work at the class level, only at the method level 😭 