### PR TITLE
Adds method to trait to get test data

### DIFF
--- a/TestCaseTrait.php
+++ b/TestCaseTrait.php
@@ -26,7 +26,7 @@ trait TestCaseTrait {
 			return [];
 		}
 
-		$dir = str_replace( [ 'Integration', 'Unit' ], 'TestData', $dir );
+		$dir = str_replace( [ 'Integration', 'Unit' ], 'Fixtures', $dir );
 		$dir = rtrim( $dir, '\\/' );
 		$testdata = "$dir/{$filename}.php";
 

--- a/TestCaseTrait.php
+++ b/TestCaseTrait.php
@@ -14,6 +14,28 @@ trait TestCaseTrait {
 	}
 
 	/**
+	 * Gets the test data, if it exists, for this test class.
+	 *
+	 * @param string $dir      Directory of the test class.
+	 * @param string $filename Test data filename without the .php extension.
+	 *
+	 * @return array array of test data.
+	 */
+	protected function getTestData( $dir, $filename ) {
+		if ( empty( $dir ) || empty( $filename ) ) {
+			return [];
+		}
+
+		$dir = str_replace( [ 'Integration', 'Unit' ], 'TestData', $dir );
+		$dir = rtrim( $dir, '\\/' );
+		$testdata = "$dir/{$filename}.php";
+
+		return is_readable( $testdata )
+			? require $testdata
+			: [];
+	}
+
+	/**
 	 * Get reflective access to the private/protected method.
 	 *
 	 * @param string $method_name Method name for which to gain access.


### PR DESCRIPTION
Adds a method to the test trait to get the test data from the `Fixtures` folder for the given test class.

What is this?

We want to drive our test suites towards using test data. Why? It makes it easier to add more and more scenario based checks without writing new tests for them.

Here's how it works:

1. Each test class that needs test data:
      - add its filesystem structure to match the test class itself.
      - add the test data .php file that returns an array of test data for the Data Provider.
3. Then in your test class' data provider, you would add:

```php
public function addDataProvider() {
	return $this->getTestData( __DIR__, 'name-of-test-data-file-without-php-ext' );
}
```

This approach makes the handling of loading test data the same for both Integration and Unit tests.