### PR TITLE
Virtual Filesystem Improvements - structure config & new get listings methods

### DIFF
--- a/ArrayTrait.php
+++ b/ArrayTrait.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace WPMedia\PHPUnit;
+
+trait ArrayTrait {
+
+	/**
+	 * Flatten a multi-dimensional associative array with the delimiter.
+	 *
+	 * @param array  $array     Array to flatten.
+	 * @param string $prepend   Optional. String to prepend to key.
+	 * @param bool   $arrayOnly Optional. When true, only processes when value is an array.
+	 *
+	 * @return array flattened array
+	 */
+	public static function flatten( array $array, $prepend = '', $arrayOnly = false, $delimiter = '/' ) {
+		$results = [];
+
+		foreach ( $array as $key => $value ) {
+			if ( $arrayOnly ) {
+				if ( ! is_array( $value ) ) {
+					continue;
+				}
+				$results[ "{$prepend}{$key}" ] = $value;
+			}
+			if ( ( $arrayOnly || is_array( $value ) ) && ! empty( $value ) ) {
+				$results = array_merge(
+					$results,
+					static::flatten( $value, "{$prepend}{$key}{$delimiter}", $arrayOnly, $delimiter )
+				);
+			} elseif ( ! $arrayOnly ) {
+				$results[ "{$prepend}{$key}" ] = $value;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Get an item from an array using delimiter notation.
+	 *
+	 * @param array  $search    Search array.
+	 * @param string $keyToFind Key to find.
+	 * @param mixed  $default   Optional. Default value to return if key does not exist in search array.
+	 * @param string $delimiter Optional. The keys' delimiter, i.e. what separating the keys.
+	 *
+	 * @return mixed value returned.
+	 */
+	public static function get( $search, $keyToFind, $default = null, $delimiter = '/' ) {
+		if ( ! is_array( $search ) ) {
+			return $default;
+		}
+
+		if ( is_null( $keyToFind ) ) {
+			return $search;
+		}
+
+		if ( array_key_exists( $keyToFind, $search ) ) {
+			return $search[ $keyToFind ];
+		}
+
+		foreach ( explode( $delimiter, $keyToFind ) as $segment ) {
+			if ( is_array( $search ) && array_key_exists( $segment, $search ) ) {
+				$search = $search[ $segment ];
+			} else {
+				return $default;
+			}
+		}
+
+		return $search;
+	}
+
+	/**
+	 * Check if an item exists in an array using delimiter notation.
+	 *
+	 * @param array  $search    Search array.
+	 * @param string $keyToFind Key to find.
+	 * @param string $delimiter Optional. The keys' delimiter, i.e. what separates the keys.
+	 *
+	 * @return bool
+	 */
+	public static function has( array $search, $keyToFind, $delimiter = '/' ) {
+		if ( empty( $search ) ) {
+			return false;
+		}
+
+		if ( is_null( $keyToFind ) ) {
+			return false;
+		}
+
+		if ( array_key_exists( $keyToFind, $search ) ) {
+			return true;
+		}
+
+		foreach ( explode( $delimiter, $keyToFind ) as $segment ) {
+			if ( array_key_exists( $segment, $search ) ) {
+				$search = $search[ $segment ];
+			} else {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/Integration/VirtualFilesystemTestCase.php
+++ b/Integration/VirtualFilesystemTestCase.php
@@ -3,32 +3,33 @@
 namespace WPMedia\PHPUnit\Integration;
 
 use Brains\Monkey\Functions;
-use WPMedia\PHPUnit\VirtualFilesystemDirect;
+use WPMedia\PHPUnit\VirtualFilesystemTestTrait;
 
 abstract class VirtualFilesystemTestCase extends TestCase {
+
+	use VirtualFilesystemTestTrait;
+
+	/**
+	 * Path to the Fixtures directory.
+	 *
+	 * @var string
+	 */
+	protected static $path_to_fixtures_dir;
+
+	/**
+	 * Path to the config and test data in the Fixtures directory.
+	 * Set this path in each test class.
+	 *
+	 * @var string
+	 */
+	protected $path_to_test_data;
 
 	/**
 	 * The root virtual directory name.
 	 *
 	 * @var string
 	 */
-	protected $rootVirtualDir = 'cache';
-
-	/**
-	 * Virtual Directory filesystem structure under the root virtual directory.
-	 *
-	 * @var array
-	 */
-	protected $structure = [
-		'busting'      => [
-			'1' => [],
-		],
-		'critical-css' => [],
-		'min'          => [],
-		'wp-rocket'    => [
-			'index.html' => '',
-		],
-	];
+	protected $rootVirtualDir = 'public';
 
 	/**
 	 * Virtual directory and file permissions.
@@ -38,26 +39,11 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $permissions = 0777;
 
 	/**
-	 * Instance of the virtual filesystem.
-	 *
-	 * @var VirtualFilesystemDirect
-	 */
-	protected $filesystem;
-
-	/**
-	 * URL to the root directory of the virtual filesystem.
-	 *
-	 * @var string
-	 */
-	protected $rootVirtualUrl;
-
-	/**
 	 * Prepares the test environment before each test.
 	 */
 	public function setUp() {
-		parent::setUp();
+		$this->init();
 
-		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
-		$this->rootVirtualUrl = $this->filesystem->getUrl( $this->rootVirtualDir );
+		parent::setUp();
 	}
 }

--- a/Tests/Fixtures/structure.php
+++ b/Tests/Fixtures/structure.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+	'vfs_dir'   => 'public/',
+
+	// Virtual filesystem structure.
+	'structure' => [
+		'Tests' => [
+			'Integration'  => [],
+			'Unit'         => [
+				'bootstrap.php' => 'Donec turpis ante, aliquam vitae egestas ac, rhoncus ut quam.',
+				'SomeClass'     => [
+					'getFile.php' => '',
+				],
+			],
+			'includes'     => [],
+			'TestCase.php' => 'Maecenas eget erat ligula.',
+		],
+		'baz'   => [
+			'index.html' => 'Lorem ipsum dolor sit amet.',
+		],
+	],
+
+	// Test data.
+	'test_data' => [],
+];

--- a/Tests/Unit/VirtualFilesystemDirect/TestCase.php
+++ b/Tests/Unit/VirtualFilesystemDirect/TestCase.php
@@ -7,9 +7,7 @@ use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 abstract class TestCase extends VirtualFilesystemTestCase {
 	protected $path_to_test_data = 'structure.php';
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		static::$path_to_fixtures_dir = WPMEDIA_PHPUNIT_ROOT_DIR . '/Tests/Fixtures/';
+	public function getPathToFixturesDir() {
+		return WPMEDIA_PHPUNIT_ROOT_DIR . '/Tests/Fixtures/';
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/TestCase.php
+++ b/Tests/Unit/VirtualFilesystemDirect/TestCase.php
@@ -12,25 +12,4 @@ abstract class TestCase extends VirtualFilesystemTestCase {
 
 		static::$path_to_fixtures_dir = WPMEDIA_PHPUNIT_ROOT_DIR . '/Tests/Fixtures/';
 	}
-
-	/**
-	 * Gets the default virtual directory filesystem structure.
-	 *
-	 * @return array default structure.
-	 */
-	private function getDefaultVfs() {
-		return [
-			'wp-admin'      => [],
-			'wp-content'    => [
-				'mu-plugins' => [],
-				'plugins'    => [
-					'wp-rocket' => [],
-				],
-				'themes'     => [],
-				'uploads'    => [],
-			],
-			'wp-includes'   => [],
-			'wp-config.php' => '',
-		];
-	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/TestCase.php
+++ b/Tests/Unit/VirtualFilesystemDirect/TestCase.php
@@ -5,21 +5,32 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
 use WPMedia\PHPUnit\Unit\VirtualFilesystemTestCase;
 
 abstract class TestCase extends VirtualFilesystemTestCase {
+	protected $path_to_test_data = 'structure.php';
 
-	protected $structure = [
-		'Tests' => [
-			'Integration'  => [],
-			'Unit'         => [
-				'bootstrap.php' => 'Donec turpis ante, aliquam vitae egestas ac, rhoncus ut quam.',
-				'SomeClass'     => [
-					'getFile.php' => '',
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		static::$path_to_fixtures_dir = WPMEDIA_PHPUNIT_ROOT_DIR . '/Tests/Fixtures/';
+	}
+
+	/**
+	 * Gets the default virtual directory filesystem structure.
+	 *
+	 * @return array default structure.
+	 */
+	private function getDefaultVfs() {
+		return [
+			'wp-admin'      => [],
+			'wp-content'    => [
+				'mu-plugins' => [],
+				'plugins'    => [
+					'wp-rocket' => [],
 				],
+				'themes'     => [],
+				'uploads'    => [],
 			],
-			'includes'     => [],
-			'TestCase.php' => 'Maecenas eget erat ligula.',
-		],
-		'baz'   => [
-			'index.html' => 'Lorem ipsum dolor sit amet.',
-		],
-	];
+			'wp-includes'   => [],
+			'wp-config.php' => '',
+		];
+	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/chmod.php
+++ b/Tests/Unit/VirtualFilesystemDirect/chmod.php
@@ -8,7 +8,7 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Chmod extends TestCase {
 
-	function testShouldChangeFileModeWhenFileExists() {
+	public function testShouldChangeFileModeWhenFileExists() {
 		$file = $this->filesystem->getFile( 'baz/index.html' ) ;
 		$original = $file->getPermissions();
 		$this->assertTrue( $this->filesystem->chmod( 'baz/index.html', 0600 ) );
@@ -26,12 +26,12 @@ class Test_Chmod extends TestCase {
 		$this->assertSame( 0644, $file->getPermissions() );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
+	public function testShouldReturnFalseWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->chmod( 'doesnotexist.html', 0600 ) );
 		$this->assertFalse( $this->filesystem->chmod( 'baz/doesnotexist.html', 0755 ) );
 	}
 
-	function testShouldChangeDirModeWhenExists() {
+	public function testShouldChangeDirModeWhenExists() {
 		$dir = $this->filesystem->getDir( 'Tests/Unit' ) ;
 		$original = $dir->getPermissions();
 		$this->assertTrue( $this->filesystem->chmod( 'Tests/Unit', 0600 ) );
@@ -40,17 +40,17 @@ class Test_Chmod extends TestCase {
 		$this->assertTrue( $this->filesystem->chmod( 'Tests/Unit', 0755 ) );
 		$this->assertSame( 0755, $dir->getPermissions() );
 
-		$dir = $this->filesystem->getDir( 'cache/baz/' ) ;
+		$dir = $this->filesystem->getDir( 'public/baz/' ) ;
 		$original = $dir->getPermissions();
-		$this->assertTrue( $this->filesystem->chmod( 'cache/baz/', 0600 ) );
+		$this->assertTrue( $this->filesystem->chmod( 'public/baz/', 0600 ) );
 		$this->assertNotEquals( $original, $dir->getPermissions() );
 		$this->assertSame( 0600, $dir->getPermissions() );
-		$this->assertTrue( $this->filesystem->chmod( 'cache/baz/', 0644 ) );
+		$this->assertTrue( $this->filesystem->chmod( 'public/baz/', 0644 ) );
 		$this->assertSame( 0644, $dir->getPermissions() );
 	}
 
-	function testShouldReturnFalseWhenDirDoesNotExist() {
-		$this->assertFalse( $this->filesystem->chmod( 'cache/Invalid/', 0600 ) );
-		$this->assertFalse( $this->filesystem->chmod( 'cache/Tests/Unit/Invalid', 0755 ) );
+	public function testShouldReturnFalseWhenDirDoesNotExist() {
+		$this->assertFalse( $this->filesystem->chmod( 'public/Invalid/', 0600 ) );
+		$this->assertFalse( $this->filesystem->chmod( 'public/Tests/Unit/Invalid', 0755 ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/delete.php
+++ b/Tests/Unit/VirtualFilesystemDirect/delete.php
@@ -8,7 +8,7 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Delete extends TestCase {
 
-	function testShouldDeleteFileWhenExists() {
+	public function testShouldDeleteFileWhenExists() {
 		$file = 'baz/index.html';
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 		$this->assertTrue( $this->filesystem->delete( $file ) );
@@ -21,7 +21,7 @@ class Test_Delete extends TestCase {
 		$this->assertFalse( $this->filesystem->exists( $file ) );
 	}
 
-	function testShouldDeleteDirWhenExistsAndEmpty() {
+	public function testShouldDeleteDirWhenExistsAndEmpty() {
 		$file = 'Tests/includes/';
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 		$this->assertTrue( $this->filesystem->delete( $file ) );
@@ -34,8 +34,8 @@ class Test_Delete extends TestCase {
 		$this->assertFalse( $this->filesystem->exists( $file ) );
 	}
 
-	function testShouldNotDeleteDirWhenNotEmpty() {
-		$file = 'cache/baz/';
+	public function testShouldNotDeleteDirWhenNotEmpty() {
+		$file = 'public/baz/';
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 		$this->assertFalse( $this->filesystem->delete( $file ) );
 		$this->assertTrue( $this->filesystem->exists( $file ) );
@@ -47,7 +47,7 @@ class Test_Delete extends TestCase {
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 	}
 
-	function testShouldDeleteDirWhenNotEmpty() {
+	public function testShouldDeleteDirWhenNotEmpty() {
 		$file = 'baz/';
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 		$this->assertTrue( $this->filesystem->delete( $file, true ) );
@@ -60,7 +60,7 @@ class Test_Delete extends TestCase {
 		$this->assertFalse( $this->filesystem->exists( $file ) );
 
 		// Check that it removes the root directory.
-		$file = 'cache';
+		$file = 'public';
 		$this->assertTrue( $this->filesystem->exists( $file ) );
 		$this->assertTrue( $this->filesystem->rmdir( $file, true ) );
 		$this->assertFalse( $this->filesystem->exists( $file ) );

--- a/Tests/Unit/VirtualFilesystemDirect/exists.php
+++ b/Tests/Unit/VirtualFilesystemDirect/exists.php
@@ -8,25 +8,25 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Exists extends TestCase {
 
-	function testShouldReturnTrueWhenFileExists() {
+	public function testShouldReturnTrueWhenFileExists() {
 		$this->assertTrue( $this->filesystem->exists( 'Tests/Unit/bootstrap.php' ) );
 		$this->assertTrue( $this->filesystem->exists( 'Tests/Unit/SomeClass/getFile.php' ) );
-		$this->assertTrue( $this->filesystem->exists( 'cache/baz/index.html' ) );
+		$this->assertTrue( $this->filesystem->exists( 'public/baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
+	public function testShouldReturnFalseWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Unit/invalid.php' ) );
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Unit/SomeClass/invalid.php' ) );
 	}
 
-	function testShouldReturnTrueWhenDirExists() {
+	public function testShouldReturnTrueWhenDirExists() {
 		$this->assertTrue( $this->filesystem->exists( 'Tests' ) );
 		$this->assertTrue( $this->filesystem->exists( 'Tests/Unit/' ) );
 		$this->assertTrue( $this->filesystem->exists( 'Tests/Unit/SomeClass' ) );
 		$this->assertTrue( $this->filesystem->exists( 'baz' ) );
 	}
 
-	function testShouldReturnFalseWhenDirDoesNotExist() {
+	public function testShouldReturnFalseWhenDirDoesNotExist() {
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Rocket' ) );
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Invalid/' ) );
 	}

--- a/Tests/Unit/VirtualFilesystemDirect/getContents.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getContents.php
@@ -8,14 +8,14 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_GetContents extends TestCase {
 
-	function testShouldReturnContentsWhenFileExists() {
-		$this->assertSame( $this->structure['baz']['index.html'], $this->filesystem->get_contents( 'cache/baz/index.html' ) );
-		$this->assertSame( $this->structure['Tests']['Unit']['bootstrap.php'], $this->filesystem->get_contents( 'cache/Tests/Unit/bootstrap.php' ) );
+	public function testShouldReturnContentsWhenFileExists() {
+		$this->assertSame( $this->structure['baz']['index.html'], $this->filesystem->get_contents( 'public/baz/index.html' ) );
+		$this->assertSame( $this->structure['Tests']['Unit']['bootstrap.php'], $this->filesystem->get_contents( 'public/Tests/Unit/bootstrap.php' ) );
 		$this->assertSame( $this->structure['Tests']['Unit']['SomeClass']['getFile.php'], $this->filesystem->get_contents( 'Tests/Unit/SomeClass/getFile.php' ) );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
+	public function testShouldReturnFalseWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->get_contents( 'baz/invalid.html' ) );
-		$this->assertFalse( $this->filesystem->get_contents( 'cache/Tests/Unit/invalid.php' ) );
+		$this->assertFalse( $this->filesystem->get_contents( 'public/Tests/Unit/invalid.php' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/getDir.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getDir.php
@@ -8,15 +8,15 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_GetDir extends TestCase {
 
-	function testShouldReturnInstanceWhenDirExists() {
+	public function testShouldReturnInstanceWhenDirExists() {
 		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamDirectory', $this->filesystem->getDir( 'Tests/Unit/SomeClass' ) );
-		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamDirectory', $this->filesystem->getDir( 'cache/Tests/' ) );
+		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamDirectory', $this->filesystem->getDir( 'public/Tests/' ) );
 		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamDirectory', $this->filesystem->getDir( 'baz' ) );
 	}
 
-	function testShouldReturnNullWhenDirDoesNotExist() {
-		$this->assertNull( $this->filesystem->getDir( 'cache/Invalid/' ) );
+	public function testShouldReturnNullWhenDirDoesNotExist() {
+		$this->assertNull( $this->filesystem->getDir( 'public/Invalid/' ) );
 		$this->assertNull( $this->filesystem->getDir( 'Invalid/' ) );
-		$this->assertNull( $this->filesystem->getDir( 'cache/Tests/Unit/Invalid' ) );
+		$this->assertNull( $this->filesystem->getDir( 'public/Tests/Unit/Invalid' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/getDirsListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getDirsListing.php
@@ -10,13 +10,13 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
 class Test_GetDirsListing extends TestCase {
 
 	/**
-	 * @dataProvider addDataProvider
+	 * @dataProvider listingTestData
 	 */
 	public function testShouldReturnListingOfAllDirs( $dir, $expected ) {
 		$this->assertSame( $expected, $this->filesystem->getDirsListing( $dir ) );
 	}
 
-	public function addDataProvider() {
+	public function listingTestData() {
 		return [
 			[
 				'Tests/Integration/',

--- a/Tests/Unit/VirtualFilesystemDirect/getDirsListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getDirsListing.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
+
+/**
+ * @covers WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect::getDirsListing
+ * @group  VirtualFilesystemDirect
+ * @group  listing
+ */
+class Test_GetDirsListing extends TestCase {
+
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldReturnListingOfAllDirs( $dir, $expected ) {
+		$this->assertSame( $expected, $this->filesystem->getDirsListing( $dir ) );
+	}
+
+	public function addDataProvider() {
+		return [
+			[
+				'Tests/Integration/',
+				[],
+			],
+			[
+				'baz/',
+				[],
+			],
+			[
+				'Tests/Unit',
+				[
+					'vfs://public/Tests/Unit/SomeClass/',
+				],
+			],
+			[
+				'Tests/',
+				[
+					'vfs://public/Tests/Integration/',
+					'vfs://public/Tests/Unit/',
+					'vfs://public/Tests/Unit/SomeClass/',
+					'vfs://public/Tests/includes/',
+				],
+			],
+			[
+				'/',
+				[
+					'vfs://public/Tests/',
+					'vfs://public/Tests/Integration/',
+					'vfs://public/Tests/Unit/',
+					'vfs://public/Tests/Unit/SomeClass/',
+					'vfs://public/Tests/includes/',
+					'vfs://public/baz/',
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/VirtualFilesystemDirect/getFile.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getFile.php
@@ -8,15 +8,15 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_GetFile extends TestCase {
 
-	function testShouldReturnInstanceOfFileWhenFileExists() {
+	public function testShouldReturnInstanceOfFileWhenFileExists() {
 		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamFile', $this->filesystem->getFile( 'Tests/Unit/SomeClass/getFile.php' ) );
-		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamFile', $this->filesystem->getFile( 'cache/Tests/TestCase.php' ) );
+		$this->assertInstanceOf( 'org\bovigo\vfs\vfsStreamFile', $this->filesystem->getFile( 'public/Tests/TestCase.php' ) );
 	}
 
-	function testShouldReturnNullWhenFileDoesNotExist() {
+	public function testShouldReturnNullWhenFileDoesNotExist() {
 		$this->assertNull( $this->filesystem->getFile( 'doesnotexist.html' ) );
 		$this->assertNull( $this->filesystem->getFile( 'Tests/includes/index.php' ) );
 		$this->assertNull( $this->filesystem->getFile( 'baz/bar/index.php' ) );
-		$this->assertNull( $this->filesystem->getFile( 'cache/Tests/includes/index.php' ) );
+		$this->assertNull( $this->filesystem->getFile( 'public/Tests/includes/index.php' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
 
 /**

--- a/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
+
+/**
+ * @covers WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect::getFilesListing
+ * @group  VirtualFilesystemDirect
+ * @group  listing
+ */
+class Test_GetFilesListing extends TestCase {
+
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldReturnListingOfAllFiles( $dir, $expected ) {
+		$this->assertSame( $expected, $this->filesystem->getFilesListing( $dir ) );
+	}
+
+	public function addDataProvider() {
+		return [
+			[
+				'Tests/Integration/',
+				[],
+			],
+			[
+				'baz/',
+				[
+					'vfs://public/baz/index.html',
+				],
+			],
+			[
+				'Tests/Unit/SomeClass',
+				[
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+				],
+			],
+			[
+				'Tests/Unit/',
+				[
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+				],
+			],
+			[
+				'Tests/',
+				[
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+					'vfs://public/Tests/TestCase.php',
+				],
+			],
+			[
+				'/',
+				[
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+					'vfs://public/Tests/TestCase.php',
+					'vfs://public/baz/index.html',
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getFilesListing.php
@@ -10,13 +10,13 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
 class Test_GetFilesListing extends TestCase {
 
 	/**
-	 * @dataProvider addDataProvider
+	 * @dataProvider listingTestData
 	 */
 	public function testShouldReturnListingOfAllFiles( $dir, $expected ) {
 		$this->assertSame( $expected, $this->filesystem->getFilesListing( $dir ) );
 	}
 
-	public function addDataProvider() {
+	public function listingTestData() {
 		return [
 			[
 				'Tests/Integration/',

--- a/Tests/Unit/VirtualFilesystemDirect/getListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getListing.php
@@ -10,13 +10,13 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
 class Test_GetListing extends TestCase {
 
 	/**
-	 * @dataProvider addDataProvider
+	 * @dataProvider listingTestData
 	 */
 	public function testShouldReturnListingOfAllFilesAndDirs( $dir, $expected ) {
 		$this->assertSame( $expected, $this->filesystem->getListing( $dir ) );
 	}
 
-	public function addDataProvider() {
+	public function listingTestData() {
 		return [
 			[
 				'Tests/Integration/',

--- a/Tests/Unit/VirtualFilesystemDirect/getListing.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getListing.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
+
+/**
+ * @covers WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect::getListing
+ * @group  VirtualFilesystemDirect
+ * @group  listing
+ */
+class Test_GetListing extends TestCase {
+
+	/**
+	 * @dataProvider addDataProvider
+	 */
+	public function testShouldReturnListingOfAllFilesAndDirs( $dir, $expected ) {
+		$this->assertSame( $expected, $this->filesystem->getListing( $dir ) );
+	}
+
+	public function addDataProvider() {
+		return [
+			[
+				'Tests/Integration/',
+				[],
+			],
+			[
+				'baz/',
+				[
+					'vfs://public/baz/index.html',
+				],
+			],
+			[
+				'Tests/Unit',
+				[
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+				],
+			],
+			[
+				'Tests/',
+				[
+					'vfs://public/Tests/Integration/',
+					'vfs://public/Tests/Unit/',
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+					'vfs://public/Tests/includes/',
+					'vfs://public/Tests/TestCase.php',
+				],
+			],
+			[
+				'/',
+				[
+					'vfs://public/Tests/',
+					'vfs://public/Tests/Integration/',
+					'vfs://public/Tests/Unit/',
+					'vfs://public/Tests/Unit/bootstrap.php',
+					'vfs://public/Tests/Unit/SomeClass/',
+					'vfs://public/Tests/Unit/SomeClass/getFile.php',
+					'vfs://public/Tests/includes/',
+					'vfs://public/Tests/TestCase.php',
+					'vfs://public/baz/',
+					'vfs://public/baz/index.html',
+				],
+			],
+		];
+	}
+}

--- a/Tests/Unit/VirtualFilesystemDirect/getUrl.php
+++ b/Tests/Unit/VirtualFilesystemDirect/getUrl.php
@@ -8,13 +8,13 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_GetUrl extends TestCase {
 
-	function testShouldReturnURLFileWhenFileExists() {
-		$this->assertSame( 'vfs://cache/Tests/Unit/SomeClass/getFile.php', $this->filesystem->getUrl( 'Tests/Unit/SomeClass/getFile.php' ) );
-		$this->assertSame( 'vfs://cache/Tests/TestCase.php', $this->filesystem->getUrl( 'cache/Tests/TestCase.php' ) );
+	public function testShouldReturnURLFileWhenFileExists() {
+		$this->assertSame( 'vfs://public/Tests/Unit/SomeClass/getFile.php', $this->filesystem->getUrl( 'Tests/Unit/SomeClass/getFile.php' ) );
+		$this->assertSame( 'vfs://public/Tests/TestCase.php', $this->filesystem->getUrl( 'public/Tests/TestCase.php' ) );
 	}
 
-	function testShouldReturnUrlWhenFileDoesNotExist() {
-		$this->assertSame( 'vfs://cache/doesnotexist.html', $this->filesystem->getUrl( 'doesnotexist.html' ) );
-		$this->assertSame( 'vfs://cache/Tests/includes/index.php', $this->filesystem->getUrl( 'Tests/includes/index.php' ) );
+	public function testShouldReturnUrlWhenFileDoesNotExist() {
+		$this->assertSame( 'vfs://public/doesnotexist.html', $this->filesystem->getUrl( 'doesnotexist.html' ) );
+		$this->assertSame( 'vfs://public/Tests/includes/index.php', $this->filesystem->getUrl( 'Tests/includes/index.php' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/isDir.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isDir.php
@@ -8,20 +8,20 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_IsDir extends TestCase {
 
-	function testShouldReturnTrueWhenDir() {
+	public function testShouldReturnTrueWhenDir() {
 		$this->assertTrue( $this->filesystem->is_dir( 'Tests' ) );
 		$this->assertTrue( $this->filesystem->is_dir( 'Tests/Unit/' ) );
 		$this->assertTrue( $this->filesystem->is_dir( 'Tests/Unit/SomeClass' ) );
 		$this->assertTrue( $this->filesystem->is_dir( 'baz' ) );
 	}
 
-	function testShouldReturnFalseWhenFileGiven() {
+	public function testShouldReturnFalseWhenFileGiven() {
 		$this->assertFalse( $this->filesystem->is_dir( 'Tests/Unit/bootstrap.php' ) );
 		$this->assertFalse( $this->filesystem->is_dir( 'Tests/Unit/SomeClass/getFile.php' ) );
-		$this->assertFalse( $this->filesystem->is_dir( 'cache/baz/index.html' ) );
+		$this->assertFalse( $this->filesystem->is_dir( 'public/baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenDirDoesNotExist() {
+	public function testShouldReturnFalseWhenDirDoesNotExist() {
 		$this->assertFalse( $this->filesystem->is_dir( 'Tests/Rocket' ) );
 		$this->assertFalse( $this->filesystem->is_dir( 'Tests/Invalid/' ) );
 	}

--- a/Tests/Unit/VirtualFilesystemDirect/isFile.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isFile.php
@@ -8,20 +8,20 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_IsFile extends TestCase {
 
-	function testShouldReturnTrueWhenFileExists() {
+	public function testShouldReturnTrueWhenFileExists() {
 		$this->assertTrue( $this->filesystem->is_file( 'Tests/Unit/bootstrap.php' ) );
 		$this->assertTrue( $this->filesystem->is_file( 'Tests/Unit/SomeClass/getFile.php' ) );
-		$this->assertTrue( $this->filesystem->is_file( 'cache/baz/index.html' ) );
+		$this->assertTrue( $this->filesystem->is_file( 'public/baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenDir() {
+	public function testShouldReturnFalseWhenDir() {
 		$this->assertFalse( $this->filesystem->is_file( 'Tests' ) );
 		$this->assertFalse( $this->filesystem->is_file( 'Tests/Unit/' ) );
 		$this->assertFalse( $this->filesystem->is_file( 'Tests/Unit/SomeClass' ) );
 		$this->assertFalse( $this->filesystem->is_file( 'baz' ) );
 	}
 
-	function testShouldReturnTrueWhenFileDoesNotExist() {
+	public function testShouldReturnTrueWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->is_file( 'Tests/Unit/index.php' ) );
 		$this->assertFalse( $this->filesystem->is_file( 'Tests/Unit/SomeClass/index.php' ) );
 	}

--- a/Tests/Unit/VirtualFilesystemDirect/isReadable.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isReadable.php
@@ -7,20 +7,19 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  * @group  VirtualFilesystemDirect
  */
 class Test_IsReadable extends TestCase {
-	protected $structure = [ 'index.html' => 'Lorem ipsum dolor sit amet.' 	];
 
-	function testShouldReturnTrueWhenFileExistsAndIsReadable() {
-		$this->assertTrue( $this->filesystem->is_readable( 'index.html' ) );
-		$this->assertTrue( $this->filesystem->is_readable( 'cache/index.html' ) );
+	public function testShouldReturnTrueWhenFileExistsAndIsReadable() {
+		$this->assertTrue( $this->filesystem->is_readable( 'baz/index.html' ) );
+		$this->assertTrue( $this->filesystem->is_readable( 'public/baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenNoAccess() {
-		$file = $this->filesystem->getFile( 'index.html' ) ;
+	public function testShouldReturnFalseWhenNoAccess() {
+		$file = $this->filesystem->getFile( 'baz/index.html' );
 		$file->chmod( 000 ); // Only root user.
-		$this->assertFalse( $this->filesystem->is_readable( 'index.html' ) );
+		$this->assertFalse( $this->filesystem->is_readable( 'baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
+	public function testShouldReturnFalseWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->is_readable( 'doesnotexist.html' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/isWritable.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isWritable.php
@@ -7,21 +7,19 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  * @group  VirtualFilesystemDirect
  */
 class Test_IsWritable extends TestCase {
-	protected $structure = [ 'index.html' => 'Lorem ipsum dolor sit amet.' 	];
 
-
-	function testShouldReturnTrueWhenFileExistsAndIsReadable() {
-		$this->assertTrue( $this->filesystem->is_writable( 'index.html' ) );
-		$this->assertTrue( $this->filesystem->is_writable( 'cache/index.html' ) );
+	public function testShouldReturnTrueWhenFileExistsAndIsReadable() {
+		$this->assertTrue( $this->filesystem->is_writable( 'baz/index.html' ) );
+		$this->assertTrue( $this->filesystem->is_writable( 'public/baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenNoAccess() {
-		$file = $this->filesystem->getFile( 'index.html' ) ;
+	public function testShouldReturnFalseWhenNoAccess() {
+		$file = $this->filesystem->getFile( 'baz/index.html' );
 		$file->chmod( 000 ); // Only root user.
-		$this->assertFalse( $this->filesystem->is_writable( 'index.html' ) );
+		$this->assertFalse( $this->filesystem->is_writable( 'baz/index.html' ) );
 	}
 
-	function testShouldReturnFalseWhenFileDoesNotExist() {
+	public function testShouldReturnFalseWhenFileDoesNotExist() {
 		$this->assertFalse( $this->filesystem->is_writable( 'doesnotexist.html' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/mkdir.php
+++ b/Tests/Unit/VirtualFilesystemDirect/mkdir.php
@@ -8,8 +8,8 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Mkdir extends TestCase {
 
-	function testShouldAddDirWhenDoesNot() {
-		$dir = 'cache/newDir/';
+	public function testShouldAddDirWhenDoesNot() {
+		$dir = 'public/newDir/';
 		$this->assertFalse( $this->filesystem->exists( $dir ) );
 		$this->assertTrue( $this->filesystem->mkdir( $dir ) );
 		$this->assertTrue( $this->filesystem->exists( $dir ) );
@@ -20,8 +20,8 @@ class Test_Mkdir extends TestCase {
 		$this->assertTrue( $this->filesystem->exists( $dir ) );
 	}
 
-	function testShouldReturnFalseWhenDirExists() {
-		$dir = 'cache/baz/';
+	public function testShouldReturnFalseWhenDirExists() {
+		$dir = 'public/baz/';
 		$this->assertTrue( $this->filesystem->exists( $dir ) );
 		$this->assertFalse( $this->filesystem->mkdir( $dir ) );
 		$this->assertTrue( $this->filesystem->exists( $dir ) );
@@ -32,16 +32,16 @@ class Test_Mkdir extends TestCase {
 		$this->assertTrue( $this->filesystem->exists( $dir ) );
 	}
 
-	function testShouldReturnFalseWhenMultipleNewDirs() {
+	public function testShouldReturnFalseWhenMultipleNewDirs() {
 		$dir = 'baz/newDir/newChildDir/newChildChildDir';
 		$this->assertFalse( $this->filesystem->exists( $dir ) );
 		$this->assertFalse( $this->filesystem->mkdir( $dir ) );
-		$this->assertFalse( $this->filesystem->exists( 'cache/baz/newDir' ) );
+		$this->assertFalse( $this->filesystem->exists( 'public/baz/newDir' ) );
 		$this->assertFalse( $this->filesystem->exists( $dir ) );
 	}
 
-	function testShouldAddDirWithNewPermissionsWhenDirDoesNotAndModeGiven() {
-		$dir = 'cache/newDir/';
+	public function testShouldAddDirWithNewPermissionsWhenDirDoesNotAndModeGiven() {
+		$dir = 'public/newDir/';
 		$this->assertFalse( $this->filesystem->exists( $dir ) );
 
 		$this->assertTrue( $this->filesystem->mkdir( $dir, 0600 ) );

--- a/Tests/Unit/VirtualFilesystemDirect/putContents.php
+++ b/Tests/Unit/VirtualFilesystemDirect/putContents.php
@@ -8,12 +8,12 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_PutContents extends TestCase {
 
-	function testShouldPutContentsWhenFileExists() {
-		$original = $this->filesystem->get_contents( 'cache/baz/index.html' );
+	public function testShouldPutContentsWhenFileExists() {
+		$original = $this->filesystem->get_contents( 'public/baz/index.html' );
 		$content  = 'New contents';
-		$this->assertTrue( $this->filesystem->put_contents( 'cache/baz/index.html', $content ) );
-		$this->assertNotSame( $original, $this->filesystem->get_contents( 'cache/baz/index.html' ) );
-		$this->assertSame( $content, $this->filesystem->get_contents( 'cache/baz/index.html' ) );
+		$this->assertTrue( $this->filesystem->put_contents( 'public/baz/index.html', $content ) );
+		$this->assertNotSame( $original, $this->filesystem->get_contents( 'public/baz/index.html' ) );
+		$this->assertSame( $content, $this->filesystem->get_contents( 'public/baz/index.html' ) );
 
 		$original = $this->filesystem->get_contents( 'Tests/Unit/SomeClass/getFile.php' );
 		$content  = 'New contents';
@@ -22,10 +22,10 @@ class Test_PutContents extends TestCase {
 		$this->assertSame( $content, $this->filesystem->get_contents( 'Tests/Unit/SomeClass/getFile.php' ) );
 	}
 
-	function testShouldCreateFileAndPutContentsWhenFileDoesNotExist() {
+	public function testShouldCreateFileAndPutContentsWhenFileDoesNotExist() {
 		$data = [
 			'baz/newfile.html' => 'Lorem ipsum dolor sit amet',
-			'cache/Tests/Unit/SomeClass/putContents.php' => 'Praesent a nibh in nulla dapibus gravida.',
+			'public/Tests/Unit/SomeClass/putContents.php' => 'Praesent a nibh in nulla dapibus gravida.',
 		];
 		foreach( $data as $filename => $content ) {
 			$this->assertFalse( $this->filesystem->exists( $filename ) );
@@ -35,7 +35,7 @@ class Test_PutContents extends TestCase {
 		}
 
 		// Test with fopen() just to be sure.
-		$filename = 'cache/Tests/Unit/SomeClass/createNewFile.php';
+		$filename = 'public/Tests/Unit/SomeClass/createNewFile.php';
 		$this->assertFalse( $this->filesystem->exists( $filename ) );
 		$fp = @fopen( $this->filesystem->getUrl( $filename ), 'wb' );
 		if ( $fp ) {

--- a/Tests/Unit/VirtualFilesystemDirect/rmdir.php
+++ b/Tests/Unit/VirtualFilesystemDirect/rmdir.php
@@ -8,7 +8,7 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Rmdir extends TestCase {
 
-	function testShouldRemoveWhenDirExistsAndEmpty() {
+	public function testShouldRemoveWhenDirExistsAndEmpty() {
 		$this->assertTrue( $this->filesystem->exists( 'Tests/includes/' ) );
 		$this->assertTrue( $this->filesystem->rmdir( 'Tests/includes/' ) );
 		$this->assertFalse( $this->filesystem->exists( 'Tests/includes/' ) );
@@ -18,17 +18,17 @@ class Test_Rmdir extends TestCase {
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Integration/' ) );
 	}
 
-	function testShouldNotRemoveWhenDirNotEmpty() {
-		$this->assertTrue( $this->filesystem->exists( 'cache/baz/' ) );
-		$this->assertFalse( $this->filesystem->rmdir( 'cache/baz/' ) );
-		$this->assertTrue( $this->filesystem->exists( 'cache/baz/' ) );
+	public function testShouldNotRemoveWhenDirNotEmpty() {
+		$this->assertTrue( $this->filesystem->exists( 'public/baz/' ) );
+		$this->assertFalse( $this->filesystem->rmdir( 'public/baz/' ) );
+		$this->assertTrue( $this->filesystem->exists( 'public/baz/' ) );
 
 		$this->assertTrue( $this->filesystem->exists( 'Tests' ) );
 		$this->assertFalse( $this->filesystem->rmdir( 'Tests', false, 'd' ) );
 		$this->assertTrue( $this->filesystem->exists( 'Tests' ) );
 	}
 
-	function testShouldRemoveWhenRecursiveAndNotEmpty() {
+	public function testShouldRemoveWhenRecursiveAndNotEmpty() {
 		$this->assertTrue( $this->filesystem->exists( 'baz/' ) );
 		$this->assertTrue( $this->filesystem->rmdir( 'baz/', true ) );
 		$this->assertFalse( $this->filesystem->exists( 'baz/' ) );
@@ -38,9 +38,9 @@ class Test_Rmdir extends TestCase {
 		$this->assertFalse( $this->filesystem->exists( 'Tests/Unit/' ) );
 
 		// Check that it removes the root directory.
-		$this->assertTrue( $this->filesystem->exists( 'cache' ) );
-		$this->assertTrue( $this->filesystem->rmdir( 'cache', true ) );
-		$this->assertFalse( $this->filesystem->exists( 'cache' ) );
-		$this->assertFalse( $this->filesystem->is_dir( 'cache' ) );
+		$this->assertTrue( $this->filesystem->exists( 'public' ) );
+		$this->assertTrue( $this->filesystem->rmdir( 'public', true ) );
+		$this->assertFalse( $this->filesystem->exists( 'public' ) );
+		$this->assertFalse( $this->filesystem->is_dir( 'public' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/setFilemtime.php
+++ b/Tests/Unit/VirtualFilesystemDirect/setFilemtime.php
@@ -8,29 +8,28 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_SetFilemtime extends TestCase {
 
-	function testShouldChangeFilemtimeWhenStringGivenAndFileExists() {
+	public function testShouldChangeFilemtimeWhenStringGivenAndFileExists() {
 		$expected = strtotime( '11 hours ago' );
 		$this->assertSame( $expected, $this->filesystem->setFilemtime( 'Tests/Unit/SomeClass/getFile.php', '11 hours ago' ) );
 		$this->assertSame( $expected, $this->filesystem->getFile( 'Tests/Unit/SomeClass/getFile.php' )->filemtime() );
 
 		$expected = strtotime( '+1 week' );
-		$this->assertSame( $expected, $this->filesystem->setFilemtime( 'cache/Tests/Unit/SomeClass/getFile.php', '+1 week' ) );
-		$this->assertSame( $expected, $this->filesystem->getFile( 'cache/Tests/Unit/SomeClass/getFile.php' )->filemtime() );
+		$this->assertSame( $expected, $this->filesystem->setFilemtime( 'public/Tests/Unit/SomeClass/getFile.php', '+1 week' ) );
+		$this->assertSame( $expected, $this->filesystem->getFile( 'public/Tests/Unit/SomeClass/getFile.php' )->filemtime() );
 	}
 
-	function testShouldChangeFilemtimeWhenTimeGivenAndFileExists() {
+	public function testShouldChangeFilemtimeWhenTimeGivenAndFileExists() {
 		$time = strtotime( 'now' );
 		$this->assertSame( $time, $this->filesystem->setFilemtime( 'Tests/Unit/SomeClass/getFile.php', $time ) );
 		$this->assertSame( $time, $this->filesystem->getFile( 'Tests/Unit/SomeClass/getFile.php' )->filemtime() );
 
 		$time = strtotime( 'next Thursday' );
-		$this->assertSame( $time, $this->filesystem->setFilemtime( 'cache/Tests/Unit/SomeClass/getFile.php', $time ) );
-		$this->assertSame( $time, $this->filesystem->getFile( 'cache/Tests/Unit/SomeClass/getFile.php' )->filemtime() );
+		$this->assertSame( $time, $this->filesystem->setFilemtime( 'public/Tests/Unit/SomeClass/getFile.php', $time ) );
+		$this->assertSame( $time, $this->filesystem->getFile( 'public/Tests/Unit/SomeClass/getFile.php' )->filemtime() );
 	}
 
-
-	function testShouldChangeFilemtimeWhenFileGiven() {
-		$file = $this->filesystem->getFile( 'cache/Tests/Unit/SomeClass/getFile.php' );
+	public function testShouldChangeFilemtimeWhenFileGiven() {
+		$file = $this->filesystem->getFile( 'public/Tests/Unit/SomeClass/getFile.php' );
 
 		$current_filemtime = $file->filemtime();
 		$time              = strtotime( 'last Monday' );
@@ -38,8 +37,8 @@ class Test_SetFilemtime extends TestCase {
 		$this->assertNotSame( $current_filemtime, $file->filemtime() );
 	}
 
-	function testShouldReturnNullWhenFileDoesNotExist() {
+	public function testShouldReturnNullWhenFileDoesNotExist() {
 		$this->assertNull( $this->filesystem->setFilemtime( 'Tests/includes/index.php', 'now' ) );
-		$this->assertNull( $this->filesystem->setFilemtime( 'cache/Tests/index.php', 'now' ) );
+		$this->assertNull( $this->filesystem->setFilemtime( 'public/Tests/index.php', 'now' ) );
 	}
 }

--- a/Tests/Unit/VirtualFilesystemDirect/touch.php
+++ b/Tests/Unit/VirtualFilesystemDirect/touch.php
@@ -8,24 +8,24 @@ namespace WPMedia\PHPUnit\Tests\Unit\VirtualFilesystemDirect;
  */
 class Test_Touch extends TestCase {
 
-	function testShouldChangeModifiedAndAccessTimesWhenFileExists() {
+	public function testShouldChangeModifiedAndAccessTimesWhenFileExists() {
 		$path = 'baz/index.html';
 		$this->assertTrue( $this->filesystem->touch( $path, 303, 313 ) );
 		$file = $this->filesystem->getFile( $path );
 		$this->assertEquals( 303, $file->filemtime() );
 		$this->assertEquals( 313, $file->fileatime() );
 
-		$path = 'cache/Tests/Unit/SomeClass/getFile.php';
+		$path = 'public/Tests/Unit/SomeClass/getFile.php';
 		$this->assertTrue( $this->filesystem->touch( $path, 603, 613 ) );
 		$file = $this->filesystem->getFile( $path );
 		$this->assertEquals( 603, $file->filemtime() );
 		$this->assertEquals( 613, $file->fileatime() );
 	}
 
-	function testShouldChangeModifiedAndAccessTimesWhenFileExistsAndTimesNotGiven() {
+	public function testShouldChangeModifiedAndAccessTimesWhenFileExistsAndTimesNotGiven() {
 		$time = strtotime( '11 hours ago' );
 
-		foreach ( [ 'baz/index.html', 'cache/Tests/Unit/SomeClass/getFile.php' ] as $path ) {
+		foreach ( [ 'baz/index.html', 'public/Tests/Unit/SomeClass/getFile.php' ] as $path ) {
 			$file = $this->filesystem->getFile( $path );
 			$file->lastModified( $time );
 			$file->lastAccessed( $time );
@@ -35,15 +35,15 @@ class Test_Touch extends TestCase {
 		}
 	}
 
-	function testShouldCreateFileWhenDoesNotExist() {
-		foreach ( [ 'baz/newfile.html', 'cache/Tests/Unit/SomeClass/newfile.php' ] as $path ) {
+	public function testShouldCreateFileWhenDoesNotExist() {
+		foreach ( [ 'baz/newfile.html', 'public/Tests/Unit/SomeClass/newfile.php' ] as $path ) {
 			$this->assertTrue( $this->filesystem->touch( $path ) );
 			$this->assertTrue( $this->filesystem->exists( $path ) );
 			$this->assertTrue( $this->filesystem->is_file( $path ) );
 		}
 
 		// Check when giving time(s).
-		$path = 'cache/Tests/Unit/newfile.php';
+		$path = 'public/Tests/Unit/newfile.php';
 		$time = strtotime( '11 hours ago' );
 		$this->assertTrue( $this->filesystem->touch( $path, $time, $time ) );
 		$this->assertTrue( $this->filesystem->exists( $path ) );

--- a/Unit/VirtualFilesystemTestCase.php
+++ b/Unit/VirtualFilesystemTestCase.php
@@ -3,9 +3,27 @@
 namespace WPMedia\PHPUnit\Unit;
 
 use Brains\Monkey\Functions;
+use WPMedia\PHPUnit\ArrayTrait;
 use WPMedia\PHPUnit\VirtualFilesystemDirect;
 
 abstract class VirtualFilesystemTestCase extends TestCase {
+
+	use ArrayTrait;
+
+	/**
+	 * Path to the Fixtures directory.
+	 *
+	 * @var string
+	 */
+	protected static $path_to_fixtures_dir;
+
+	/**
+	 * Path to the config and test data in the Fixtures directory.
+	 * Set this path in each test class.
+	 *
+	 * @var string
+	 */
+	protected $path_to_test_data;
 
 	/**
 	 * The root virtual directory name.
@@ -15,27 +33,15 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $rootVirtualDir = 'public';
 
 	/**
-	 * Virtual Directory filesystem structure under the root virtual directory.
-	 *
-	 * @var array
-	 */
-	protected $structure = [
-		'busting'      => [
-			'1' => [],
-		],
-		'critical-css' => [],
-		'min'          => [],
-		'wp-rocket'    => [
-			'index.html' => '',
-		],
-	];
-
-	/**
 	 * Virtual directory and file permissions.
 	 *
 	 * @var int
 	 */
 	protected $permissions = 0777;
+
+	/**
+	 * Do not overwrite these properties.
+	 */
 
 	/**
 	 * Instance of the virtual filesystem.
@@ -45,6 +51,13 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $filesystem;
 
 	/**
+	 * Overwrite with the structure for this test. Gets merged with the default structure.
+	 *
+	 * @var array
+	 */
+	protected $structure = [];
+
+	/**
 	 * URL to the root directory of the virtual filesystem.
 	 *
 	 * @var string
@@ -52,12 +65,100 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $rootVirtualUrl;
 
 	/**
+	 * Structure + test data configuration.
+	 *
+	 * @var array
+	 */
+	protected $config = [];
+
+	/**
+	 * Virtual filestructure for this test, i.e. default merged with configured.
+	 *
+	 * @var array
+	 */
+	private $merged_structure = [];
+
+	/**
+	 * Original virtual files with flattened full paths.
+	 *
+	 * @var array
+	 */
+	protected $original_files = [];
+
+	/**
+	 * Original virtual directories with flattened full paths.
+	 *
+	 * @var array
+	 */
+	protected $original_dirs = [];
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	public function setUp() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
 
-		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->structure, $this->permissions );
-		$this->rootVirtualUrl = $this->filesystem->getUrl( $this->rootVirtualDir );
+		$vfs                  = ArrayTrait::get( $this->config['structure'], rtrim( $this->config['vfs_dir'], '\//' ), [], '/' );
+		$this->original_files = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'] ) );
+		$this->original_dirs  = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'], true ) );
+
+		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->mergeStructure(), $this->permissions );
+		$this->rootVirtualUrl = $this->filesystem->getUrl( '/' );
+
+		parent::setUp();
+	}
+
+	/**
+	 * Test Data Provider that uses the `'test_data'` in the config file.
+	 *
+	 * @return mixed
+	 */
+	public function providerTestData() {
+		$this->loadConfig();
+
+		return $this->config['test_data'];
+	}
+
+	/**
+	 * Loads the configuration for the vfs structure and test data.
+	 */
+	protected function loadConfig() {
+		$path         = ! empty( static::$path_to_fixtures_dir )
+			? static::$path_to_fixtures_dir . $this->path_to_test_data
+			: $this->path_to_test_data;
+		$this->config = require $path;
+	}
+
+	/**
+	 * Merges the configured and default virtual filesystem structures.
+	 *
+	 * @return array merged structure
+	 */
+	protected function mergeStructure() {
+		// If already merged, return it.
+		if ( ! empty( $this->merged_structure ) ) {
+			return $this->merged_structure;
+		}
+
+		$this->structure        = $this->config['structure'];
+		$this->merged_structure = array_replace_recursive( $this->getDefaultVfs(), $this->config['structure'] );
+
+		return $this->merged_structure;
+	}
+
+	/**
+	 * Gets the default virtual directory filesystem structure.
+	 *
+	 * @return array default structure.
+	 */
+	private function getDefaultVfs() {
+		return [
+			'Tests' => [
+				'Integration' => [],
+				'Unit'        => [],
+			],
+		];
 	}
 }

--- a/Unit/VirtualFilesystemTestCase.php
+++ b/Unit/VirtualFilesystemTestCase.php
@@ -10,13 +10,6 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	use VirtualFilesystemTestTrait;
 
 	/**
-	 * Path to the Fixtures directory.
-	 *
-	 * @var string
-	 */
-	protected static $path_to_fixtures_dir;
-
-	/**
 	 * Path to the config and test data in the Fixtures directory.
 	 * Set this path in each test class.
 	 *

--- a/Unit/VirtualFilesystemTestCase.php
+++ b/Unit/VirtualFilesystemTestCase.php
@@ -3,12 +3,11 @@
 namespace WPMedia\PHPUnit\Unit;
 
 use Brains\Monkey\Functions;
-use WPMedia\PHPUnit\ArrayTrait;
-use WPMedia\PHPUnit\VirtualFilesystemDirect;
+use WPMedia\PHPUnit\VirtualFilesystemTestTrait;
 
 abstract class VirtualFilesystemTestCase extends TestCase {
 
-	use ArrayTrait;
+	use VirtualFilesystemTestTrait;
 
 	/**
 	 * Path to the Fixtures directory.
@@ -40,112 +39,12 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	protected $permissions = 0777;
 
 	/**
-	 * Do not overwrite these properties.
-	 */
-
-	/**
-	 * Instance of the virtual filesystem.
-	 *
-	 * @var VirtualFilesystemDirect
-	 */
-	protected $filesystem;
-
-	/**
-	 * Overwrite with the structure for this test. Gets merged with the default structure.
-	 *
-	 * @var array
-	 */
-	protected $structure = [];
-
-	/**
-	 * URL to the root directory of the virtual filesystem.
-	 *
-	 * @var string
-	 */
-	protected $rootVirtualUrl;
-
-	/**
-	 * Structure + test data configuration.
-	 *
-	 * @var array
-	 */
-	protected $config = [];
-
-	/**
-	 * Virtual filestructure for this test, i.e. default merged with configured.
-	 *
-	 * @var array
-	 */
-	private $merged_structure = [];
-
-	/**
-	 * Original virtual files with flattened full paths.
-	 *
-	 * @var array
-	 */
-	protected $original_files = [];
-
-	/**
-	 * Original virtual directories with flattened full paths.
-	 *
-	 * @var array
-	 */
-	protected $original_dirs = [];
-
-	/**
 	 * Prepares the test environment before each test.
 	 */
 	public function setUp() {
-		if ( empty( $this->config ) ) {
-			$this->loadConfig();
-		}
-
-		$vfs                  = ArrayTrait::get( $this->config['structure'], rtrim( $this->config['vfs_dir'], '\//' ), [], '/' );
-		$this->original_files = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'] ) );
-		$this->original_dirs  = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'], true ) );
-
-		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->mergeStructure(), $this->permissions );
-		$this->rootVirtualUrl = $this->filesystem->getUrl( '/' );
+		$this->init();
 
 		parent::setUp();
-	}
-
-	/**
-	 * Test Data Provider that uses the `'test_data'` in the config file.
-	 *
-	 * @return mixed
-	 */
-	public function providerTestData() {
-		$this->loadConfig();
-
-		return $this->config['test_data'];
-	}
-
-	/**
-	 * Loads the configuration for the vfs structure and test data.
-	 */
-	protected function loadConfig() {
-		$path         = ! empty( static::$path_to_fixtures_dir )
-			? static::$path_to_fixtures_dir . $this->path_to_test_data
-			: $this->path_to_test_data;
-		$this->config = require $path;
-	}
-
-	/**
-	 * Merges the configured and default virtual filesystem structures.
-	 *
-	 * @return array merged structure
-	 */
-	protected function mergeStructure() {
-		// If already merged, return it.
-		if ( ! empty( $this->merged_structure ) ) {
-			return $this->merged_structure;
-		}
-
-		$this->structure        = $this->config['structure'];
-		$this->merged_structure = array_replace_recursive( $this->getDefaultVfs(), $this->config['structure'] );
-
-		return $this->merged_structure;
 	}
 
 	/**
@@ -153,7 +52,7 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	 *
 	 * @return array default structure.
 	 */
-	private function getDefaultVfs() {
+	public function getDefaultVfs() {
 		return [
 			'Tests' => [
 				'Integration' => [],

--- a/Unit/VirtualFilesystemTestCase.php
+++ b/Unit/VirtualFilesystemTestCase.php
@@ -12,7 +12,7 @@ abstract class VirtualFilesystemTestCase extends TestCase {
 	 *
 	 * @var string
 	 */
-	protected $rootVirtualDir = 'cache';
+	protected $rootVirtualDir = 'public';
 
 	/**
 	 * Virtual Directory filesystem structure under the root virtual directory.

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -2,10 +2,13 @@
 
 namespace WPMedia\PHPUnit;
 
+use FilesystemIterator;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamAbstractContent;
 use org\bovigo\vfs\vfsStreamFile;
 use org\bovigo\vfs\vfsStreamDirectory;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Virtual filesystem (emulates WP_Filesystem_Direct) using vfsStream.
@@ -41,9 +44,10 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string $rootDirname Optional. Name of the root filesystem directory.
 	 * @param array  $structure   Optional. Starting filesystem structure for the root directory.
 	 * @param int    $permissions Optional. File permissions for the root directory.
+	 *
+	 * @param string $rootDirname Optional. Name of the root filesystem directory.
 	 */
 	public function __construct( $rootDirname = 'cache', array $structure = [], $permissions = 0755 ) {
 		$this->root        = rtrim( $rootDirname, '/\\' );
@@ -103,8 +107,9 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string|vfsStreamFile $file      Absolute path to file when string or instance of vfsStreamFile.
 	 * @param string|int           $filectime Last modification time to set for the file.
+	 *
+	 * @param string|vfsStreamFile $file      Absolute path to file when string or instance of vfsStreamFile.
 	 *
 	 * @return int file's filectime when file exists; else null.
 	 */
@@ -146,9 +151,10 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string    $filename Absolute path to file.
 	 * @param string    $contents The data to write.
 	 * @param int|false $mode     Optional. The file permissions as octal number, usually 0644. Default false.
+	 *
+	 * @param string    $filename Absolute path to file.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -197,10 +203,11 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string    $fileOrDir Path to the file or directory.
 	 * @param int|false $mode      Optional. The permissions as octal number, usually 0644 for files,
 	 *                             0755 for directories. Default false.
 	 * @param bool      $recursive Optional. If set to true, changes file group recursively. Default false.
+	 *
+	 * @param string    $fileOrDir Path to the file or directory.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -227,9 +234,10 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string       $fileOrDir Path to the file or directory.
 	 * @param bool         $recursive Optional. If set to true, changes file group recursively. Default false.
 	 * @param string|false $type      Optional. Type of resource. 'f' for file, 'd' for directory. Default false.
+	 *
+	 * @param string       $fileOrDir Path to the file or directory.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -266,6 +274,26 @@ class VirtualFilesystemDirect {
 			||
 			$this->is_file( $fileOrDir )
 		);
+	}
+
+	/**
+	 * Gets a list of all the files within the given virtual root directory.
+	 *
+	 * @param string $dir Virtual directory absolute path.
+	 *
+	 * @return array all files within the given root directory.
+	 */
+	public function getFilesListing( $dir ) {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS )
+		);
+
+		$items = [];
+		foreach ( $iterator as $item ) {
+			$items[] = $item->getPathname();
+		}
+
+		return $items;
 	}
 
 	/**
@@ -333,8 +361,9 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string    $path  Path for new directory.
 	 * @param int|false $chmod Optional. The permissions as octal number (or false to skip chmod). Default false.
+	 *
+	 * @param string    $path  Path for new directory.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -353,8 +382,9 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string $dir       Path to directory.
 	 * @param bool   $recursive Optional. Whether to recursively remove files/directories. Default false.
+	 *
+	 * @param string $dir       Path to directory.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -393,11 +423,12 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string $file  Path to file.
 	 * @param int    $time  Optional. Modified time to set for file.
 	 *                      Default 0.
 	 * @param int    $atime Optional. Access time to set for file.
 	 *                      Default 0.
+	 *
+	 * @param string $file  Path to file.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -417,8 +448,9 @@ class VirtualFilesystemDirect {
 	 *
 	 * @since 1.1
 	 *
-	 * @param string             $dirname Child directory name.
 	 * @param vfsStreamDirectory $child   Instance of the child directory.
+	 *
+	 * @param string             $dirname Child directory name.
 	 *
 	 * @return vfsStreamDirectory|null parent directory on success; null when no parent directory.
 	 */

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -321,6 +321,31 @@ class VirtualFilesystemDirect {
 	}
 
 	/**
+	 * Gets a list of all the files and directories within the given virtual root directory.
+	 *
+	 * @param string $dir Virtual directory absolute path.
+	 *
+	 * @return array all files and directories within the given root directory.
+	 */
+	public function getListing( $dir ) {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::SELF_FIRST
+		);
+
+		$items = [];
+		foreach ( $iterator as $item ) {
+			if ( $item->isDir() ) {
+				$items[] = $item->getPathname() . DIRECTORY_SEPARATOR;
+			} else {
+				$items[] = $item->getPathname();
+			}
+		}
+
+		return $items;
+	}
+
+	/**
 	 * Checks if resource is a directory.
 	 *
 	 * @since 1.1

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -281,23 +281,10 @@ class VirtualFilesystemDirect {
 	 *
 	 * @param string $dir Virtual directory absolute path.
 	 *
-	 * @return array all directories within the given root directory.
+	 * @return array of all directories.
 	 */
 	public function getDirsListing( $dir ) {
-		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS ),
-			RecursiveIteratorIterator::SELF_FIRST
-		);
-
-		$items = [];
-		foreach ( $iterator as $item ) {
-			if ( ! $item->isDir() ) {
-				continue;
-			}
-			$items[] = $item->getPathname() . DIRECTORY_SEPARATOR;
-		}
-
-		return $items;
+		return $this->scanFS( $dir, true );
 	}
 
 	/**
@@ -305,19 +292,10 @@ class VirtualFilesystemDirect {
 	 *
 	 * @param string $dir Virtual directory absolute path.
 	 *
-	 * @return array all files within the given root directory.
+	 * @return array of all files.
 	 */
 	public function getFilesListing( $dir ) {
-		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS )
-		);
-
-		$items = [];
-		foreach ( $iterator as $item ) {
-			$items[] = $item->getPathname();
-		}
-
-		return $items;
+		return $this->scanFS( $dir, false, true );
 	}
 
 	/**
@@ -325,19 +303,32 @@ class VirtualFilesystemDirect {
 	 *
 	 * @param string $dir Virtual directory absolute path.
 	 *
-	 * @return array all files and directories within the given root directory.
+	 * @return array of all files and directories.
 	 */
 	public function getListing( $dir ) {
+		return $this->scanFS( $dir );
+	}
+
+	/**
+	 * Scans the filesystem and returns a list of files, directories, or both within the given virtual root directory.
+	 *
+	 * @param string  $dir       Virtual directory absolute path.
+	 * @param boolean $dirOnly   Optional. When true, returns only directories.
+	 * @param boolean $filesOnly Optional. When true, returns only files.
+	 *
+	 * @return array of all files, directories, or both.
+	 */
+	protected function scanFS( $dir, $dirOnly = false, $filesOnly = false ) {
 		$iterator = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS ),
-			RecursiveIteratorIterator::SELF_FIRST
+			$filesOnly ? RecursiveIteratorIterator::LEAVES_ONLY : RecursiveIteratorIterator::SELF_FIRST
 		);
 
 		$items = [];
 		foreach ( $iterator as $item ) {
-			if ( $item->isDir() ) {
+			if ( ! $filesOnly && $item->isDir() ) {
 				$items[] = $item->getPathname() . DIRECTORY_SEPARATOR;
-			} else {
+			} elseif ( ! $dirOnly ) {
 				$items[] = $item->getPathname();
 			}
 		}

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -277,6 +277,30 @@ class VirtualFilesystemDirect {
 	}
 
 	/**
+	 * Gets a list of all the directories within the given virtual root directory.
+	 *
+	 * @param string $dir Virtual directory absolute path.
+	 *
+	 * @return array all directories within the given root directory.
+	 */
+	public function getDirsListing( $dir ) {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $this->getUrl( $dir ), FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::SELF_FIRST
+		);
+
+		$items = [];
+		foreach ( $iterator as $item ) {
+			if ( ! $item->isDir() ) {
+				continue;
+			}
+			$items[] = $item->getPathname() . DIRECTORY_SEPARATOR;
+		}
+
+		return $items;
+	}
+
+	/**
 	 * Gets a list of all the files within the given virtual root directory.
 	 *
 	 * @param string $dir Virtual directory absolute path.

--- a/VirtualFilesystemTestTrait.php
+++ b/VirtualFilesystemTestTrait.php
@@ -88,10 +88,16 @@ trait VirtualFilesystemTestTrait {
 	 * Loads the configuration for the vfs structure and test data.
 	 */
 	protected function loadConfig() {
-		$path         = ! empty( static::$path_to_fixtures_dir )
-			? static::$path_to_fixtures_dir . $this->path_to_test_data
-			: $this->path_to_test_data;
-		$this->config = require $path;
+		$this->config = require $this->getPathToFixturesDir() . $this->path_to_test_data;
+	}
+
+	/**
+	 * Overload in your test case with the path to the Fixtures directory.
+	 *
+	 * @return string
+	 */
+	public function getPathToFixturesDir() {
+		return '';
 	}
 
 	/**

--- a/VirtualFilesystemTestTrait.php
+++ b/VirtualFilesystemTestTrait.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace WPMedia\PHPUnit;
+
+use Brains\Monkey\Functions;
+
+trait VirtualFilesystemTestTrait {
+
+	use ArrayTrait;
+
+	/**
+	 * Instance of the virtual filesystem.
+	 *
+	 * @var VirtualFilesystemDirect
+	 */
+	protected $filesystem;
+
+	/**
+	 * Overwrite with the structure for this test. Gets merged with the default structure.
+	 *
+	 * @var array
+	 */
+	protected $structure = [];
+
+	/**
+	 * URL to the root directory of the virtual filesystem.
+	 *
+	 * @var string
+	 */
+	protected $rootVirtualUrl;
+
+	/**
+	 * Structure + test data configuration.
+	 *
+	 * @var array
+	 */
+	protected $config = [];
+
+	/**
+	 * Virtual filestructure for this test, i.e. default merged with configured.
+	 *
+	 * @var array
+	 */
+	private $merged_structure = [];
+
+	/**
+	 * Original virtual files with flattened full paths.
+	 *
+	 * @var array
+	 */
+	protected $original_files = [];
+
+	/**
+	 * Original virtual directories with flattened full paths.
+	 *
+	 * @var array
+	 */
+	protected $original_dirs = [];
+
+	/**
+	 * Initializes the test environment.
+	 */
+	public function init() {
+		if ( empty( $this->config ) ) {
+			$this->loadConfig();
+		}
+
+		$vfs                  = ArrayTrait::get( $this->config['structure'], rtrim( $this->config['vfs_dir'], '\//' ), [], '/' );
+		$this->original_files = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'] ) );
+		$this->original_dirs  = array_keys( ArrayTrait::flatten( $vfs, $this->config['vfs_dir'], true ) );
+
+		$this->filesystem     = new VirtualFilesystemDirect( $this->rootVirtualDir, $this->mergeStructure(), $this->permissions );
+		$this->rootVirtualUrl = $this->filesystem->getUrl( '/' );
+	}
+
+	/**
+	 * Test Data Provider that uses the `'test_data'` in the config file.
+	 *
+	 * @return mixed
+	 */
+	public function providerTestData() {
+		$this->loadConfig();
+
+		return $this->config['test_data'];
+	}
+
+	/**
+	 * Loads the configuration for the vfs structure and test data.
+	 */
+	protected function loadConfig() {
+		$path         = ! empty( static::$path_to_fixtures_dir )
+			? static::$path_to_fixtures_dir . $this->path_to_test_data
+			: $this->path_to_test_data;
+		$this->config = require $path;
+	}
+
+	/**
+	 * Merges the configured and default virtual filesystem structures.
+	 *
+	 * @return array merged structure
+	 */
+	protected function mergeStructure() {
+		// If already merged, return it.
+		if ( ! empty( $this->merged_structure ) ) {
+			return $this->merged_structure;
+		}
+
+		$this->structure        = $this->config['structure'];
+		$this->merged_structure = array_replace_recursive( $this->getDefaultVfs(), $this->config['structure'] );
+
+		return $this->merged_structure;
+	}
+
+	/**
+	 * Gets the default virtual directory filesystem structure.
+	 *
+	 * @return array default structure.
+	 */
+	public function getDefaultVfs() {
+		return [
+			'wp-admin'      => [],
+			'wp-content'    => [
+				'mu-plugins' => [],
+				'plugins'    => [
+					'wp-rocket' => [],
+				],
+				'themes'     => [
+					'twentytwenty' => [],
+				],
+				'uploads'    => [],
+			],
+			'wp-includes'   => [],
+			'wp-config.php' => '',
+		];
+	}
+}


### PR DESCRIPTION
This PR does the following:

- Sets the root of the filesystem to `public`, i.e. the root of the WordPress files
- Sets the default filesystem structure to match WordPress' default structure
- Standardizes on loading config file from Fixtures folder for filesystem structure configuration and test data
- Adds methods for getting all files, directories, or both from the given root directory
    - `getFilesListing()` -- returns a list of all the files within the given root directory
    - `getDirsListing()` --- returns a list of all the directories within the given root directory
    - `getListing()` -- returns a list of all the files and directories within the given root directory
- Adds an `ArrayTrait` to give us handlers for arrays such as: flatten an array by a delimiter notation