### PR TITLE
fix undefined property  $_error_level

### DIFF
--- a/Integration/AdminTestCase.php
+++ b/Integration/AdminTestCase.php
@@ -31,7 +31,7 @@ abstract class AdminTestCase extends TestCase {
 
 		// Suppress warnings from "Cannot modify header information - headers already sent by".
 		$this->original_error_level = error_reporting();
-		error_reporting( $this->_error_level & ~E_WARNING );
+		error_reporting( $this->original_error_level & ~E_WARNING );
 
 		do_action( 'admin_init' );
 	}


### PR DESCRIPTION
This PR is to fix  all [19 Integration tests](https://github.com/wp-media/wp-rocket/actions/runs/3384893223/jobs/5622935153) similar to `WP_Rocket\Tests\Integration\inc\Engine\Admin\Settings\Settings\Test_SanitizeCallback`
that are failing because of the following error 
```
1) WP_Rocket\Tests\Integration\inc\Engine\Admin\Settings\Settings\Test_SanitizeCallback::testShouldSanitizeDNSPrefetchEntries with data set #0 (array(), array(array()))
199 Undefined property: WP_Rocket\Tests\Integration\inc\Engine\Admin\Settings\Settings\Test_SanitizeCallback::$_error_level
200
201 /home/runner/work/wp-rocket/wp-rocket/vendor/wp-media/phpunit/Integration/AdminTestCase.php:34
202 /home/runner/work/wp-rocket/wp-rocket/tests/Integration/inc/Engine/Admin/Settings/Settings/sanitizeCallback.php:32
203 /home/runner/work/wp-rocket/wp-rocket/vendor/yoast/phpunit-polyfills/src/TestCases/TestCasePHPUnitGte8.php:56
204 phpvfscomposer:///home/runner/work/wp-rocket/wp-rocket/vendor/phpunit/phpunit/phpunit:97 
```
[Slack convo](https://wp-media.slack.com/archives/GUT7FLHF1/p1667477615411369)