### PR TITLE
Fix PHP 8.3/8.5 deprecations in TestCaseTrait reflection helpers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         wp-versions: ['latest']
 
     name: WP ${{ matrix.wp-versions }} with PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}.

--- a/TestCaseTrait.php
+++ b/TestCaseTrait.php
@@ -47,7 +47,8 @@ trait TestCaseTrait {
 	protected function get_reflective_method( $method_name, $class_name ) {
 		$class  = new ReflectionClass( $class_name );
 		$method = $class->getMethod( $method_name );
-		$method->setAccessible( true );
+
+		self::set_reflector_accessible( $method, true );
 
 		return $method;
 	}
@@ -64,7 +65,8 @@ trait TestCaseTrait {
 	protected function get_reflective_property( $property, $class ) {
 		$class    = new ReflectionClass( $class );
 		$property = $class->getProperty( $property );
-		$property->setAccessible( true );
+
+		self::set_reflector_accessible( $property, true );
 
 		return $property;
 	}
@@ -81,8 +83,15 @@ trait TestCaseTrait {
 	 */
 	protected function set_reflective_property( $value, $property, $instance ) {
 		$property = $this->get_reflective_property( $property, $instance );
-		$property->setValue( $instance, $value );
-		$property->setAccessible( false );
+
+		// A static property has no target object: passing anything but null is deprecated as of PHP 8.3.
+		if ( $property->isStatic() ) {
+			$property->setValue( null, $value );
+		} else {
+			$property->setValue( $instance, $value );
+		}
+
+		self::set_reflector_accessible( $property, false );
 
 		return $property;
 	}
@@ -90,11 +99,31 @@ trait TestCaseTrait {
 	protected function getNonPublicPropertyValue( $property, $class, $instance = null ) {
 		$property = $this->get_reflective_property( $property, $class );
 
-		if ( is_null( $instance ) ) {
+		if ( is_null( $instance ) || $property->isStatic() ) {
 			return $property->getValue();
 		}
 
 		return $property->getValue( $instance );
+	}
+
+	/**
+	 * Toggles accessibility on a reflected method or property.
+	 *
+	 * ReflectionMethod::setAccessible() and ReflectionProperty::setAccessible() have no effect since PHP 8.1, where
+	 * reflection grants access to non-public members by default, and are deprecated as of PHP 8.5. They are still
+	 * required on PHP 7.4 and 8.0.
+	 *
+	 * @param ReflectionMethod|ReflectionProperty $reflector  Reflected method or property.
+	 * @param bool                                $accessible Whether to make the member accessible.
+	 *
+	 * @return void
+	 */
+	private static function set_reflector_accessible( $reflector, $accessible ) {
+		if ( PHP_VERSION_ID >= 80100 ) {
+			return;
+		}
+
+		$reflector->setAccessible( $accessible );
 	}
 
 	/**

--- a/Tests/Unit/testTestCaseTrait.php
+++ b/Tests/Unit/testTestCaseTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit;
+
+use WPMedia\PHPUnit\Unit\TestCase;
+
+/**
+ * Target class exposing non-public members for the reflection helpers to operate on.
+ */
+class ReflectionTarget {
+
+	private $instance_property = 'initial';
+
+	private static $static_property = 'initial static';
+
+	private function secret( $suffix ) {
+		return "secret {$suffix}";
+	}
+
+	public function get_instance_property() {
+		return $this->instance_property;
+	}
+
+	public static function get_static_property() {
+		return self::$static_property;
+	}
+
+	public static function reset() {
+		self::$static_property = 'initial static';
+	}
+}
+
+/**
+ * @covers WPMedia\PHPUnit\TestCaseTrait::get_reflective_method
+ * @covers WPMedia\PHPUnit\TestCaseTrait::get_reflective_property
+ * @covers WPMedia\PHPUnit\TestCaseTrait::set_reflective_property
+ * @covers WPMedia\PHPUnit\TestCaseTrait::getNonPublicPropertyValue
+ * @group  TestCaseTrait
+ */
+class Test_TestCaseTrait extends TestCase {
+
+	protected function tear_down() {
+		ReflectionTarget::reset();
+
+		parent::tear_down();
+	}
+
+	public function testShouldSetAndGetInstancePropertyWhenGivenAnInstance() {
+		$target = new ReflectionTarget();
+
+		$this->set_reflective_property( 'changed', 'instance_property', $target );
+
+		$this->assertSame( 'changed', $target->get_instance_property() );
+		$this->assertSame( 'changed', $this->getNonPublicPropertyValue( 'instance_property', ReflectionTarget::class, $target ) );
+	}
+
+	public function testShouldSetAndGetStaticPropertyWhenGivenAClassName() {
+		$this->set_reflective_property( 'changed static', 'static_property', ReflectionTarget::class );
+
+		$this->assertSame( 'changed static', ReflectionTarget::get_static_property() );
+		$this->assertSame( 'changed static', $this->getNonPublicPropertyValue( 'static_property', ReflectionTarget::class ) );
+	}
+
+	public function testShouldSetAndGetStaticPropertyWhenGivenAnInstance() {
+		$target = new ReflectionTarget();
+
+		$this->set_reflective_property( 'changed static', 'static_property', $target );
+
+		$this->assertSame( 'changed static', ReflectionTarget::get_static_property() );
+		$this->assertSame( 'changed static', $this->getNonPublicPropertyValue( 'static_property', ReflectionTarget::class, $target ) );
+	}
+
+	public function testShouldInvokeNonPublicMethod() {
+		$method = $this->get_reflective_method( 'secret', ReflectionTarget::class );
+
+		$this->assertSame( 'secret value', $method->invoke( new ReflectionTarget(), 'value' ) );
+	}
+
+	/**
+	 * The helpers must not emit deprecations on any supported PHP version:
+	 * ReflectionProperty::setValue() with a non-object first argument is deprecated as of PHP 8.3, and
+	 * Reflection*::setAccessible() is deprecated as of PHP 8.5.
+	 *
+	 * @see https://github.com/wp-media/phpunit/issues/29
+	 */
+	public function testShouldNotTriggerDeprecationsOnAnySupportedPhpVersion() {
+		$deprecations = [];
+
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$deprecations ) {
+				$deprecations[] = $errstr;
+
+				return true;
+			},
+			E_DEPRECATED | E_USER_DEPRECATED
+		);
+
+		try {
+			$target = new ReflectionTarget();
+
+			$this->get_reflective_method( 'secret', ReflectionTarget::class );
+			$this->get_reflective_property( 'instance_property', $target );
+			$this->set_reflective_property( 'changed', 'instance_property', $target );
+			$this->set_reflective_property( 'changed static', 'static_property', ReflectionTarget::class );
+			$this->getNonPublicPropertyValue( 'static_property', ReflectionTarget::class );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( [], $deprecations );
+	}
+}


### PR DESCRIPTION
Fixes #29

## Changes

**`setValue()` on static properties.** `set_reflective_property()` forwarded `$instance` straight to `ReflectionProperty::setValue()`, but callers pass a *class name* when targeting a static property. Static properties are now set with an explicit `null` target:

```php
if ( $property->isStatic() ) {
    $property->setValue( null, $value );
} else {
    $property->setValue( $instance, $value );
}
```

**`setAccessible()`.** No-op since PHP 8.1, deprecated as of 8.5, but still required on 7.4/8.0. All four call sites now route through a private `set_reflector_accessible()` helper that returns early when `PHP_VERSION_ID >= 80100`.

**`getNonPublicPropertyValue()`** picked up an `isStatic()` check so it no longer relies on the object argument being silently ignored for static properties. Behaviour is unchanged.

The library keeps its `>=7.4` compatibility — the version guard is the reason `setAccessible()` is kept rather than deleted.

## Testing

- Both deprecations reproduced verbatim against the pre-fix code on 8.3 and 8.5, confirming the right code paths were exercised.
- New `Tests/Unit/testTestCaseTrait.php` covers instance/static property set+get (via both a class name and an instance), non-public method invocation, and asserts no `E_DEPRECATED` is emitted. That last test **fails against the old implementation** on both 8.3 and 8.5, so it is a real guard.

## Notes for the reviewer

- Pre-existing and out of scope: `get_reflective_property()` uses `ReflectionClass::getProperty()`, which does not find a private property declared on a parent class.

🤖 Generated with Claude Code