### PR TITLE
Fix PHP minimum version readiness check

### DIFF
--- a/Tests/Unit/testBootstrap.php
+++ b/Tests/Unit/testBootstrap.php
@@ -3,6 +3,7 @@
 namespace WPMedia\PHPUnit\Tests\Unit;
 
 use WPMedia\PHPUnit\Unit\TestCase;
+use function WPMedia\PHPUnit\check_readiness;
 
 class Test_Bootstrap extends TestCase {
 
@@ -15,5 +16,25 @@ class Test_Bootstrap extends TestCase {
 	function testShouldReturnTrueWhenRootBootstrapFileIsInMemory() {
 		$this->assertTrue( function_exists( __NAMESPACE__ . '\is_unit_test_bootstrap' ) );
 		$this->assertTrue( is_unit_test_bootstrap() );
+	}
+
+	function testShouldAcceptMinimumSupportedPhpVersion() {
+		$this->assertNull( check_readiness( '7.4.0' ) );
+	}
+
+	function testShouldRejectPhpVersionBelowSupportedMinimum() {
+		$error = null;
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$error ) {
+				$error = compact( 'errno', 'errstr' );
+				return true;
+			}
+		);
+
+		check_readiness( '7.3.99' );
+		restore_error_handler();
+
+		$this->assertSame( E_USER_ERROR, $error['errno'] );
+		$this->assertSame( 'Test Suite requires PHP 7.4 or higher.', $error['errstr'] );
 	}
 }

--- a/bootstrap-functions.php
+++ b/bootstrap-functions.php
@@ -18,10 +18,14 @@ function init_test_suite() {
 
 /**
  * Check the system's readiness to run the tests.
+ *
+ * @param string|null $php_version PHP version to validate. Defaults to the running version.
  */
-function check_readiness() {
-	if ( version_compare( phpversion(), '7.1.0', '<' ) ) {
-		trigger_error( 'Test Suite requires PHP 7.1 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+function check_readiness( $php_version = null ) {
+	$php_version = $php_version ?: phpversion();
+
+	if ( version_compare( $php_version, '7.4.0', '<' ) ) {
+		trigger_error( 'Test Suite requires PHP 7.4 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 	}
 
 	if ( ! file_exists( WPMEDIA_PHPUNIT_ROOT_DIR . '/vendor/autoload.php' ) ) {


### PR DESCRIPTION
Closes #38.

Aligns `check_readiness()` with Composer's declared PHP 7.4 minimum and updates the runtime error message accordingly.

The readiness function now accepts an optional version argument so the compatibility boundary can be tested without depending on the PHP version running the suite. Unit coverage verifies that 7.4.0 is accepted and 7.3.99 produces the expected `E_USER_ERROR`.

Validation:
- `git diff --check` — passed
- PHP/Composer tests were not run locally because neither executable is installed on this Windows host; the repository CI matrix will exercise PHP 7.4 through 8.5.
