### PR TITLE
Fix is_readable() to test readability, not writability

### DIFF
--- a/Tests/Integration/VirtualFilesystemDirect/dirlist.php
+++ b/Tests/Integration/VirtualFilesystemDirect/dirlist.php
@@ -17,6 +17,16 @@ class Test_DirList extends TestCase {
 		$this->assertSame( $expected, $this->filesystem->dirlist( $path ) );
 	}
 
+	public function testShouldReturnListingWhenDirectoryIsReadOnly() {
+		$dir = $this->filesystem->getDir( 'baz' );
+		$dir->chmod( 0444 ); // Read-only directory.
+
+		$listing = $this->filesystem->dirlist( 'baz' );
+
+		$this->assertNotFalse( $listing );
+		$this->assertArrayHasKey( 'index.html', $listing );
+	}
+
 	private function prepListing( $path, $entries ) {
 		$path = rtrim( $path, '\//' );
 		foreach ( $entries as $entry => $info ) {

--- a/Tests/Unit/VirtualFilesystemDirect/isReadable.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isReadable.php
@@ -13,6 +13,12 @@ class Test_IsReadable extends TestCase {
 		$this->assertTrue( $this->filesystem->is_readable( 'public/baz/index.html' ) );
 	}
 
+	public function testShouldReturnTrueWhenFileIsReadOnly() {
+		$file = $this->filesystem->getFile( 'baz/index.html' );
+		$file->chmod( 0444 ); // Read-only.
+		$this->assertTrue( $this->filesystem->is_readable( 'baz/index.html' ) );
+	}
+
 	public function testShouldReturnFalseWhenNoAccess() {
 		$file = $this->filesystem->getFile( 'baz/index.html' );
 		$file->chmod( 000 ); // Only root user.

--- a/Tests/Unit/VirtualFilesystemDirect/isWritable.php
+++ b/Tests/Unit/VirtualFilesystemDirect/isWritable.php
@@ -13,6 +13,12 @@ class Test_IsWritable extends TestCase {
 		$this->assertTrue( $this->filesystem->is_writable( 'public/baz/index.html' ) );
 	}
 
+	public function testShouldReturnFalseWhenFileIsReadOnly() {
+		$file = $this->filesystem->getFile( 'baz/index.html' );
+		$file->chmod( 0444 ); // Read-only.
+		$this->assertFalse( $this->filesystem->is_writable( 'baz/index.html' ) );
+	}
+
 	public function testShouldReturnFalseWhenNoAccess() {
 		$file = $this->filesystem->getFile( 'baz/index.html' );
 		$file->chmod( 000 ); // Only root user.

--- a/VirtualFilesystemDirect.php
+++ b/VirtualFilesystemDirect.php
@@ -581,7 +581,7 @@ class VirtualFilesystemDirect {
 	 * @return bool Whether $file is readable.
 	 */
 	public function is_readable( $file ) {
-		return is_writeable( $this->getUrl( $file ) );
+		return is_readable( $this->getUrl( $file ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`VirtualFilesystemDirect::is_readable()` delegated to `is_writeable()`, so it returned an entry's **writability** instead of its **readability**. A read-only entry (`0444`) is readable but not writable, and was wrongly reported as "not readable".

This is not cosmetic: `dirlist()` gates on `is_readable()`, so **listing a read-only directory returned `false`** — a false negative for exactly the permission scenario this filesystem mock exists to reproduce.

## Change

```php
public function is_readable( $file ) {
-	return is_writeable( $this->getUrl( $file ) );
+	return is_readable( $this->getUrl( $file ) );
}
```

## Regression coverage

- `isReadable.php`: `0444` asserts `true`
- `isWritable.php`: `0444` asserts `false` (guards against the inverse regression)
- `dirlist.php`: a read-only directory still returns its listing, not `false`

The pre-existing unit tests only covered `0777` (→ true) and `000` (→ false), both of which passed under the buggy delegation, which is why this went unnoticed.

## Validation

Ran the full suite in Docker via `wp-env` (WordPress test site, PHP 8.3.33, PHPUnit 9.6.35):

- Unit: **93 tests, 284 assertions — OK**
- Integration: **29 tests, 70 assertions — OK**
- Integration (AdminOnly): **3 tests, 4 assertions — OK**

Both new read-only cases were confirmed to execute (not silently skipped).

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)