### PR TITLE
Update .gitattributes to exclude non-production files from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,20 @@
-bin export-ignore
 Tests export-ignore
-vendor export-ignore
 
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .github export-ignore
+.wp-env.json export-ignore
 
-composer.lock export-ignore
+CLAUDE.md export-ignore
 LICENSE export-ignore
 README.md export-ignore
+
+composer.lock export-ignore
+
+package.json export-ignore
+package-lock.json export-ignore
+
+phpcs.xml.dist export-ignore
+phpstan.neon.dist export-ignore
+phpstan-baseline.neon export-ignore


### PR DESCRIPTION
## Summary

Updates the `.gitattributes` `export-ignore` rules so distribution archives (`git archive` / Composer dist installs) contain only production files.

- **Added** export-ignore for newly introduced dev/test files: `.wp-env.json`, `CLAUDE.md`, `package.json`, `package-lock.json`, `phpcs.xml.dist`, `phpstan.neon.dist`, `phpstan-baseline.neon`
- **Removed** stale `bin` and `vendor` entries — no longer tracked after production code moved under `src/` (#44); `vendor/` is gitignored
- **Kept**: `Tests`, `.editorconfig`, `.gitattributes`, `.gitignore`, `.github`, `composer.lock`, `LICENSE`, `README.md`

## Verification

`git check-attr export-ignore` confirms production files (`composer.json`, `wpmedia-phpunit`, everything under `src/`) remain in the archive, while all dev/test files are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)