### PR TITLE
Cover BootstrapManager and document the consumer entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,11 @@ composite action. Keep the `composer` scripts (`test-unit`, `test-integration`,
 
 - `composer phpcs` / `composer phpcs:fix` — WordPress Coding Standards (`phpcs.xml.dist`).
 - `composer phpstan` — PHPStan (`phpstan.neon.dist`, baseline in `phpstan-baseline.neon`).
+
+**phpcs coverage is intentionally partial.** `phpcs.xml.dist` enumerates a specific allow-list of
+files rather than scanning the whole tree (see issue #39): only files already brought up to the WP
+Media standard are listed, so CI stays green on the ~20 pre-existing files that have not been
+migrated. Add files to that list opportunistically as they are cleaned up — do **not** widen the
+scope wholesale (that would fail CI on all the unmigrated files at once). Most test files, including
+the per-method files under `Tests/`, stay out of scope by design. PHPStan, by contrast, analyzes the
+full `src/` + `Tests/` set with a baseline, so new code must be PHPStan-clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,39 @@ Guidance for AI agents working in this repository.
 unit and WordPress integration test suites for WP Media projects. Production code
 lives in `src/` (PSR-4 `WPMedia\PHPUnit\`); the package's own tests live in `Tests/`.
 
+## Architecture
+
+- **Consumer entry point** — the `wpmedia-phpunit` bin (Composer-symlinked into a consumer's
+  `vendor/bin/`) delegates to `BootstrapManager` (`src/BootstrapManager.php`), which parses argv
+  (`WPMEDIA_PHPUNIT_ROOT_DIR=`, `path=`, `--group`), derives the `WPMEDIA_PHPUNIT_ROOT_DIR` /
+  `WPMEDIA_PHPUNIT_ROOT_TEST_DIR` constants, picks the `phpunit.xml.dist` to use, and hands off to
+  PHPUnit. Downstream repos run their suites via `vendor/bin/wpmedia-phpunit unit|integration`.
+- **Bootstraps** — `src/{Unit,Integration}/bootstrap.php` load the autoloader, Patchwork, and
+  Brain\Monkey (unit) or Yoast WPIntegration (integration), then optionally require an add-on
+  bootstrap (`WPMEDIA_PHPUNIT_ADDON_ROOT_TEST_DIR`) and the consumer's own
+  `Tests/{Unit,Integration}/bootstrap.php`.
+- **Public API consumers extend** — base `Unit\TestCase` / `Integration\TestCase`, plus
+  `VirtualFilesystemTestCase`, `AdminTestCase`, `AjaxTestCase`, `RESTfulTestCase`, `RESTVfsTestCase`,
+  and the traits (`ArrayTrait`, `TestCaseTrait`, `VirtualFilesystemTestTrait`, `ApiTrait`,
+  `HttpRequestTrait`, `RESTTrait`). Changing these signatures is a breaking change for downstream repos.
+- **Integration `--group` has side effects** — `src/Integration/bootstrap.php` defines `WP_ADMIN`
+  for `--group AdminOnly` and `MULTISITE` for `--group Multisite`. That is why the integration
+  suite is split into separate composer scripts.
+
+### Test layout
+
+One class per method: `Tests/{Unit,Integration}/<Subject>/<method>.php` holding a `Test_<Method>`
+class (a per-group abstract `TestCase.php` holds shared setup), with data providers in the mirrored
+`Tests/Fixtures/<Subject>/` directory (resolved by `TestCaseTrait::getTestData()`). Test namespace is
+PSR-4 `WPMedia\PHPUnit\Tests\`. New per-method test files follow the existing style (no per-method
+doc comments) and stay **out** of the `phpcs.xml.dist` scope, alongside the other test files.
+
+> **Self-test caveat:** the package's own suite bootstraps through
+> `Tests/{Unit,Integration}/init-tests.php`, which defines the two constants directly and requires
+> `src/{Unit,Integration}/bootstrap.php` — bypassing the bin and most of `BootstrapManager`. A green
+> suite therefore does not by itself prove the consumer entry point; `BootstrapManager`'s argv
+> parsing is covered explicitly in `Tests/Unit/BootstrapManager/`.
+
 ## Running the tests — use wp-env
 
 `wp-env` is the default, supported way to run this package's tests locally. It provides

--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ When you need to customize the test case, extend off of the base test cases in t
 - For a custom integration, extend off of `WPMedia\PHPUnit\Integration\TestCase`.
 - For a custom unit, extend off of `WPMedia\PHPUnit\Unit\TestCase`.
 
+## Running Your Repo's Tests
+
+Composer symlinks this package's runner to `vendor/bin/wpmedia-phpunit`. Point your repo's own
+Composer scripts at it, passing the suite to run:
+
+```json
+"scripts": {
+	"test-unit": "wpmedia-phpunit unit",
+	"test-integration": "wpmedia-phpunit integration"
+}
+```
+
+The runner (`WPMedia\PHPUnit\BootstrapManager`) resolves where your tests and configuration live,
+then hands off to PHPUnit. It accepts a few optional arguments:
+
+- `WPMEDIA_PHPUNIT_ROOT_DIR=<path>` — the root of the repo under test. Defaults to four levels up
+  from the package's `src/` (i.e. your project root when this package is installed under
+  `vendor/`). Pass `.` to target this package itself.
+- `path=<dir>` — the test directory. Defaults to `Tests/Unit` or `Tests/Integration` depending on
+  the suite.
+- `--group <name>` — the standard PHPUnit group selector. Two groups are special during
+  integration bootstrapping: `AdminOnly` defines `WP_ADMIN` (so `is_admin()` is `true`) and
+  `Multisite` defines `MULTISITE`.
+
+Any other arguments (e.g. `--filter`) are forwarded to PHPUnit unchanged. If your repo ships its
+own `phpunit.xml.dist` in the test directory, it is used; otherwise the bundled default applies.
+
 ## Running This Package's Tests
 
 The default, supported way to run this package's own unit and integration tests locally is [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/). It spins up a disposable, Dockerized WordPress + MySQL environment with Composer, PHPUnit, and WP-CLI preinstalled, and exposes the WordPress PHPUnit test suite (`WP_TESTS_DIR`) automatically — no manual database or test-suite install required.

--- a/Tests/Fixtures/BootstrapManager/getArg.php
+++ b/Tests/Fixtures/BootstrapManager/getArg.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+	'key=value argument returns its index and value' => [
+		'argv'     => [ 'vendor/bin/wpmedia-phpunit', 'unit', 'path=Tests/Foo' ],
+		'key'      => 'path',
+		'expected' => [ 'index' => 2, 'path' => 'Tests/Foo' ],
+	],
+
+	'root-dir argument keeps its absolute path value' => [
+		'argv'     => [ 'x', 'integration', 'WPMEDIA_PHPUNIT_ROOT_DIR=/var/www/plugin' ],
+		'key'      => 'WPMEDIA_PHPUNIT_ROOT_DIR',
+		'expected' => [ 'index' => 2, 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ],
+	],
+
+	'flag without an equals sign is its own value' => [
+		'argv'     => [ 'x', 'integration', '--group', 'AdminOnly' ],
+		'key'      => '--group',
+		'expected' => [ 'index' => 2, '--group' => '--group' ],
+	],
+
+	'absent key returns false' => [
+		'argv'     => [ 'x', 'unit' ],
+		'key'      => 'path',
+		'expected' => false,
+	],
+];

--- a/Tests/Fixtures/BootstrapManager/getConfigArgv.php
+++ b/Tests/Fixtures/BootstrapManager/getConfigArgv.php
@@ -1,0 +1,54 @@
+<?php
+
+// {{unit_config}} stands in for the runtime-resolved phpunit.xml.dist path; the test substitutes
+// it before asserting.
+return [
+	'builds the base unit script when only the suite is given' => [
+		'argv'     => [ 'vendor/bin/wpmedia-phpunit', 'unit' ],
+		'test'     => 'unit',
+		'expected' => [
+			'vendor/bin/phpunit',
+			'--testsuite',
+			'unit',
+			'--colors=always',
+			'--configuration',
+			'{{unit_config}}',
+		],
+	],
+
+	'returns an empty script for an unknown suite' => [
+		'argv'     => [ 'vendor/bin/wpmedia-phpunit', 'bogus' ],
+		'test'     => 'bogus',
+		'expected' => [],
+	],
+
+	'passes through extra phpunit arguments' => [
+		'argv'     => [ 'x', 'unit', '--filter', 'testSomething' ],
+		'test'     => 'unit',
+		'expected' => [
+			'vendor/bin/phpunit',
+			'--testsuite',
+			'unit',
+			'--colors=always',
+			'--configuration',
+			'{{unit_config}}',
+			'--filter',
+			'testSomething',
+		],
+	],
+
+	'strips the consumer path and root-dir arguments' => [
+		'argv'     => [ 'x', 'unit', 'path=Tests/Custom', 'WPMEDIA_PHPUNIT_ROOT_DIR=/srv/app', '--filter', 'foo' ],
+		'test'     => 'unit',
+		'expected' => [
+			'vendor/bin/phpunit',
+			'--testsuite',
+			'unit',
+			'--colors=always',
+			'--configuration',
+			'{{unit_config}}',
+			'--filter',
+			'foo',
+		],
+	],
+];

--- a/Tests/Fixtures/BootstrapManager/getRootDir.php
+++ b/Tests/Fixtures/BootstrapManager/getRootDir.php
@@ -1,0 +1,26 @@
+<?php
+
+// The install-location-dependent expectations are tokens resolved by the test against the
+// package's actual src/ location: {{consumer_root}} = four levels up from src/ (the project root
+// when installed under vendor/), {{package_root}} = this package's own root.
+return [
+	'no root given walks up to the consumer root' => [
+		'root'     => false,
+		'expected' => '{{consumer_root}}',
+	],
+
+	'"." resolves to the package root' => [
+		'root'     => [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '.' ],
+		'expected' => '{{package_root}}',
+	],
+
+	'leading slash is stripped from an explicit root' => [
+		'root'     => [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ],
+		'expected' => 'var/www/plugin',
+	],
+
+	'a relative root is returned unchanged' => [
+		'root'     => [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => 'relative/path/to/plugin' ],
+		'expected' => 'relative/path/to/plugin',
+	],
+];

--- a/Tests/Fixtures/BootstrapManager/isGroup.php
+++ b/Tests/Fixtures/BootstrapManager/isGroup.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+	'flag matches the requested group name' => [
+		'argv'       => [ 'x', 'integration', '--group', 'AdminOnly' ],
+		'group_name' => 'AdminOnly',
+		'expected'   => true,
+	],
+
+	'flag name differs from the requested group' => [
+		'argv'       => [ 'x', 'integration', '--group', 'AdminOnly' ],
+		'group_name' => 'Multisite',
+		'expected'   => false,
+	],
+
+	'no group flag present' => [
+		'argv'       => [ 'x', 'integration' ],
+		'group_name' => 'AdminOnly',
+		'expected'   => false,
+	],
+
+	'group flag has no name after it' => [
+		'argv'       => [ 'x', 'integration', '--group' ],
+		'group_name' => 'AdminOnly',
+		'expected'   => false,
+	],
+];

--- a/Tests/Fixtures/BootstrapManager/removeCliArg.php
+++ b/Tests/Fixtures/BootstrapManager/removeCliArg.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+	'removes the matching argument in place' => [
+		'argv'     => [ 'x', 'unit', 'path=Tests/Foo', '--filter', 'bar' ],
+		'key'      => 'path',
+		// Unset leaves a gap; the remaining keys are not reindexed.
+		'expected' => [ 0 => 'x', 1 => 'unit', 3 => '--filter', 4 => 'bar' ],
+	],
+
+	'leaves argv untouched when the arg is absent' => [
+		'argv'     => [ 'x', 'unit', '--filter', 'bar' ],
+		'key'      => 'path',
+		'expected' => [ 'x', 'unit', '--filter', 'bar' ],
+	],
+];

--- a/Tests/Unit/BootstrapManager/TestCase.php
+++ b/Tests/Unit/BootstrapManager/TestCase.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+use WPMedia\PHPUnit\BootstrapManager as Subject;
+use WPMedia\PHPUnit\Unit\TestCase as BaseTestCase;
+
+/**
+ * Base test case for the {@see \WPMedia\PHPUnit\BootstrapManager} argv-parsing helpers.
+ *
+ * These tests exercise the consumer entry point (the `wpmedia-phpunit` bin + BootstrapManager)
+ * that the package's own suite bypasses: `Tests/{Unit,Integration}/init-tests.php` defines the
+ * constants directly and requires `src/{Unit,Integration}/bootstrap.php`, so BootstrapManager is
+ * otherwise never run. See CLAUDE.md ("Architecture").
+ */
+abstract class TestCase extends BaseTestCase {
+
+	/**
+	 * Snapshot of $_SERVER['argv'] taken before each test.
+	 *
+	 * @var array|null
+	 */
+	private $original_argv;
+
+	/**
+	 * Snapshot of $_SERVER['argc'] taken before each test.
+	 *
+	 * @var int|null
+	 */
+	private $original_argc;
+
+	/**
+	 * BootstrapManager reads and mutates the global argv/argc while resolving the consumer's
+	 * run configuration. Snapshot them before each test so nothing leaks into other tests.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_argv = isset( $_SERVER['argv'] ) ? $_SERVER['argv'] : null;
+		$this->original_argc = isset( $_SERVER['argc'] ) ? $_SERVER['argc'] : null;
+	}
+
+	/**
+	 * Restores the global argv/argc after each test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		if ( null === $this->original_argv ) {
+			unset( $_SERVER['argv'] );
+		} else {
+			$_SERVER['argv'] = $this->original_argv;
+		}
+
+		if ( null === $this->original_argc ) {
+			unset( $_SERVER['argc'] );
+		} else {
+			$_SERVER['argc'] = $this->original_argc;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Simulates the command line that BootstrapManager reads.
+	 *
+	 * @param array $argv Command-line arguments to simulate.
+	 *
+	 * @return void
+	 */
+	protected function setArgv( array $argv ) {
+		$_SERVER['argv'] = $argv;
+		$_SERVER['argc'] = count( $argv );
+	}
+
+	/**
+	 * Invokes a protected/private static method on BootstrapManager.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Arguments to pass through.
+	 *
+	 * @return mixed the method's return value.
+	 */
+	protected function invoke( $method, array $args = [] ) {
+		return $this->get_reflective_method( $method, Subject::class )->invokeArgs( null, $args );
+	}
+}

--- a/Tests/Unit/BootstrapManager/getArg.php
+++ b/Tests/Unit/BootstrapManager/getArg.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+/**
+ * @covers WPMedia\PHPUnit\BootstrapManager::getArg
+ * @group  BootstrapManager
+ */
+class Test_GetArg extends TestCase {
+
+	public function testShouldReturnIndexAndValueWhenKeyValueArgExists() {
+		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'unit', 'path=Tests/Foo' ] );
+
+		$this->assertSame(
+			[ 'index' => 2, 'path' => 'Tests/Foo' ],
+			$this->invoke( 'getArg', [ 'path' ] )
+		);
+	}
+
+	public function testShouldReturnRootDirArgWithItsAbsolutePathValue() {
+		$this->setArgv( [ 'x', 'integration', 'WPMEDIA_PHPUNIT_ROOT_DIR=/var/www/plugin' ] );
+
+		$this->assertSame(
+			[ 'index' => 2, 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ],
+			$this->invoke( 'getArg', [ 'WPMEDIA_PHPUNIT_ROOT_DIR' ] )
+		);
+	}
+
+	public function testShouldReturnFlagAsItsOwnValueWhenNoEqualsSign() {
+		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
+
+		// There is no `--group=` prefix to strip, so the value is the flag itself.
+		$this->assertSame(
+			[ 'index' => 2, '--group' => '--group' ],
+			$this->invoke( 'getArg', [ '--group' ] )
+		);
+	}
+
+	public function testShouldReturnFalseWhenKeyIsAbsent() {
+		$this->setArgv( [ 'x', 'unit' ] );
+
+		$this->assertFalse( $this->invoke( 'getArg', [ 'path' ] ) );
+	}
+}

--- a/Tests/Unit/BootstrapManager/getArg.php
+++ b/Tests/Unit/BootstrapManager/getArg.php
@@ -8,37 +8,16 @@ namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
  */
 class Test_GetArg extends TestCase {
 
-	public function testShouldReturnIndexAndValueWhenKeyValueArgExists() {
-		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'unit', 'path=Tests/Foo' ] );
+	/**
+	 * @dataProvider getArgDataProvider
+	 */
+	public function testShouldReturnTheParsedArg( $argv, $key, $expected ) {
+		$this->setArgv( $argv );
 
-		$this->assertSame(
-			[ 'index' => 2, 'path' => 'Tests/Foo' ],
-			$this->invoke( 'getArg', [ 'path' ] )
-		);
+		$this->assertSame( $expected, $this->invoke( 'getArg', [ $key ] ) );
 	}
 
-	public function testShouldReturnRootDirArgWithItsAbsolutePathValue() {
-		$this->setArgv( [ 'x', 'integration', 'WPMEDIA_PHPUNIT_ROOT_DIR=/var/www/plugin' ] );
-
-		$this->assertSame(
-			[ 'index' => 2, 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ],
-			$this->invoke( 'getArg', [ 'WPMEDIA_PHPUNIT_ROOT_DIR' ] )
-		);
-	}
-
-	public function testShouldReturnFlagAsItsOwnValueWhenNoEqualsSign() {
-		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
-
-		// There is no `--group=` prefix to strip, so the value is the flag itself.
-		$this->assertSame(
-			[ 'index' => 2, '--group' => '--group' ],
-			$this->invoke( 'getArg', [ '--group' ] )
-		);
-	}
-
-	public function testShouldReturnFalseWhenKeyIsAbsent() {
-		$this->setArgv( [ 'x', 'unit' ] );
-
-		$this->assertFalse( $this->invoke( 'getArg', [ 'path' ] ) );
+	public function getArgDataProvider() {
+		return $this->getTestData( __DIR__, 'getArg' );
 	}
 }

--- a/Tests/Unit/BootstrapManager/getConfigArgv.php
+++ b/Tests/Unit/BootstrapManager/getConfigArgv.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+/**
+ * @covers WPMedia\PHPUnit\BootstrapManager::getConfigArgv
+ * @group  BootstrapManager
+ */
+class Test_GetConfigArgv extends TestCase {
+
+	public function testShouldBuildTheBaseUnitScriptWhenOnlySuiteGiven() {
+		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'unit' ] );
+
+		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
+
+		$this->assertSame(
+			[ 'vendor/bin/phpunit', '--testsuite', 'unit', '--colors=always', '--configuration' ],
+			array_slice( $config, 0, 5 )
+		);
+		$this->assertStringEndsWith( 'phpunit.xml.dist', end( $config ) );
+	}
+
+	public function testShouldReturnAnEmptyScriptForAnUnknownSuite() {
+		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'bogus' ] );
+
+		$this->assertSame( [], $this->invoke( 'getConfigArgv', [ 'bogus' ] ) );
+	}
+
+	public function testShouldPassThroughExtraPhpunitArguments() {
+		$this->setArgv( [ 'x', 'unit', '--filter', 'testSomething' ] );
+
+		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
+
+		$this->assertContains( '--filter', $config );
+		$this->assertContains( 'testSomething', $config );
+	}
+
+	public function testShouldStripConsumerPathAndRootDirArguments() {
+		$this->setArgv(
+			[ 'x', 'unit', 'path=Tests/Custom', 'WPMEDIA_PHPUNIT_ROOT_DIR=/srv/app', '--filter', 'foo' ]
+		);
+
+		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
+
+		// The wpmedia-phpunit-specific args are consumed here, not forwarded to PHPUnit...
+		$this->assertNotContains( 'path=Tests/Custom', $config );
+		$this->assertNotContains( 'WPMEDIA_PHPUNIT_ROOT_DIR=/srv/app', $config );
+
+		// ...while genuine PHPUnit args still pass through.
+		$this->assertContains( '--filter', $config );
+		$this->assertContains( 'foo', $config );
+	}
+}

--- a/Tests/Unit/BootstrapManager/getConfigArgv.php
+++ b/Tests/Unit/BootstrapManager/getConfigArgv.php
@@ -8,46 +8,26 @@ namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
  */
 class Test_GetConfigArgv extends TestCase {
 
-	public function testShouldBuildTheBaseUnitScriptWhenOnlySuiteGiven() {
-		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'unit' ] );
-
-		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
-
-		$this->assertSame(
-			[ 'vendor/bin/phpunit', '--testsuite', 'unit', '--colors=always', '--configuration' ],
-			array_slice( $config, 0, 5 )
-		);
-		$this->assertStringEndsWith( 'phpunit.xml.dist', end( $config ) );
-	}
-
-	public function testShouldReturnAnEmptyScriptForAnUnknownSuite() {
-		$this->setArgv( [ 'vendor/bin/wpmedia-phpunit', 'bogus' ] );
-
-		$this->assertSame( [], $this->invoke( 'getConfigArgv', [ 'bogus' ] ) );
-	}
-
-	public function testShouldPassThroughExtraPhpunitArguments() {
-		$this->setArgv( [ 'x', 'unit', '--filter', 'testSomething' ] );
-
-		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
-
-		$this->assertContains( '--filter', $config );
-		$this->assertContains( 'testSomething', $config );
-	}
-
-	public function testShouldStripConsumerPathAndRootDirArguments() {
-		$this->setArgv(
-			[ 'x', 'unit', 'path=Tests/Custom', 'WPMEDIA_PHPUNIT_ROOT_DIR=/srv/app', '--filter', 'foo' ]
+	/**
+	 * @dataProvider getConfigArgvDataProvider
+	 */
+	public function testShouldBuildThePhpunitArgv( $argv, $test, $expected ) {
+		// getConfigArgv() resolves the config path from WPMEDIA_PHPUNIT_ROOT_TEST_DIR at runtime;
+		// swap the fixture token for that path before asserting.
+		$config_path = WPMEDIA_PHPUNIT_ROOT_TEST_DIR . '/phpunit.xml.dist';
+		$expected    = array_map(
+			static function ( $arg ) use ( $config_path ) {
+				return '{{unit_config}}' === $arg ? $config_path : $arg;
+			},
+			(array) $expected
 		);
 
-		$config = $this->invoke( 'getConfigArgv', [ 'unit' ] );
+		$this->setArgv( $argv );
 
-		// The wpmedia-phpunit-specific args are consumed here, not forwarded to PHPUnit...
-		$this->assertNotContains( 'path=Tests/Custom', $config );
-		$this->assertNotContains( 'WPMEDIA_PHPUNIT_ROOT_DIR=/srv/app', $config );
+		$this->assertSame( $expected, $this->invoke( 'getConfigArgv', [ $test ] ) );
+	}
 
-		// ...while genuine PHPUnit args still pass through.
-		$this->assertContains( '--filter', $config );
-		$this->assertContains( 'foo', $config );
+	public function getConfigArgvDataProvider() {
+		return $this->getTestData( __DIR__, 'getConfigArgv' );
 	}
 }

--- a/Tests/Unit/BootstrapManager/getRootDir.php
+++ b/Tests/Unit/BootstrapManager/getRootDir.php
@@ -12,40 +12,24 @@ use WPMedia\PHPUnit\BootstrapManager as Subject;
 class Test_GetRootDir extends TestCase {
 
 	/**
-	 * Absolute path to the package's `src` directory (where BootstrapManager lives).
-	 *
-	 * @return string
+	 * @dataProvider getRootDirDataProvider
 	 */
-	private function srcDir() {
-		return dirname( ( new ReflectionClass( Subject::class ) )->getFileName() );
+	public function testShouldResolveTheRootDir( $root, $expected ) {
+		// Resolve the install-location tokens from the fixture against the package's real src/ dir.
+		$src_dir  = dirname( ( new ReflectionClass( Subject::class ) )->getFileName() );
+		$resolved = [
+			'{{consumer_root}}' => dirname( dirname( dirname( dirname( $src_dir ) ) ) ),
+			'{{package_root}}'  => dirname( $src_dir ),
+		];
+
+		if ( is_string( $expected ) && isset( $resolved[ $expected ] ) ) {
+			$expected = $resolved[ $expected ];
+		}
+
+		$this->assertSame( $expected, $this->invoke( 'getRootDir', [ $root ] ) );
 	}
 
-	public function testShouldWalkUpToTheConsumerRootWhenNoRootGiven() {
-		// Installed as a dependency at vendor/wp-media/phpunit/src, four levels up from src is
-		// the consumer project's root.
-		$expected = dirname( dirname( dirname( dirname( $this->srcDir() ) ) ) );
-
-		$this->assertSame( $expected, $this->invoke( 'getRootDir', [ false ] ) );
-	}
-
-	public function testShouldReturnThePackageRootWhenRootIsDot() {
-		$this->assertSame(
-			dirname( $this->srcDir() ),
-			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '.' ] ] )
-		);
-	}
-
-	public function testShouldStripLeadingSlashFromAnExplicitRoot() {
-		$this->assertSame(
-			'var/www/plugin',
-			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ] ] )
-		);
-	}
-
-	public function testShouldReturnARelativeRootUnchanged() {
-		$this->assertSame(
-			'relative/path/to/plugin',
-			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => 'relative/path/to/plugin' ] ] )
-		);
+	public function getRootDirDataProvider() {
+		return $this->getTestData( __DIR__, 'getRootDir' );
 	}
 }

--- a/Tests/Unit/BootstrapManager/getRootDir.php
+++ b/Tests/Unit/BootstrapManager/getRootDir.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+use ReflectionClass;
+use WPMedia\PHPUnit\BootstrapManager as Subject;
+
+/**
+ * @covers WPMedia\PHPUnit\BootstrapManager::getRootDir
+ * @group  BootstrapManager
+ */
+class Test_GetRootDir extends TestCase {
+
+	/**
+	 * Absolute path to the package's `src` directory (where BootstrapManager lives).
+	 *
+	 * @return string
+	 */
+	private function srcDir() {
+		return dirname( ( new ReflectionClass( Subject::class ) )->getFileName() );
+	}
+
+	public function testShouldWalkUpToTheConsumerRootWhenNoRootGiven() {
+		// Installed as a dependency at vendor/wp-media/phpunit/src, four levels up from src is
+		// the consumer project's root.
+		$expected = dirname( dirname( dirname( dirname( $this->srcDir() ) ) ) );
+
+		$this->assertSame( $expected, $this->invoke( 'getRootDir', [ false ] ) );
+	}
+
+	public function testShouldReturnThePackageRootWhenRootIsDot() {
+		$this->assertSame(
+			dirname( $this->srcDir() ),
+			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '.' ] ] )
+		);
+	}
+
+	public function testShouldStripLeadingSlashFromAnExplicitRoot() {
+		$this->assertSame(
+			'var/www/plugin',
+			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => '/var/www/plugin' ] ] )
+		);
+	}
+
+	public function testShouldReturnARelativeRootUnchanged() {
+		$this->assertSame(
+			'relative/path/to/plugin',
+			$this->invoke( 'getRootDir', [ [ 'WPMEDIA_PHPUNIT_ROOT_DIR' => 'relative/path/to/plugin' ] ] )
+		);
+	}
+}

--- a/Tests/Unit/BootstrapManager/isGroup.php
+++ b/Tests/Unit/BootstrapManager/isGroup.php
@@ -10,27 +10,16 @@ use WPMedia\PHPUnit\BootstrapManager as Subject;
  */
 class Test_IsGroup extends TestCase {
 
-	public function testShouldReturnTrueWhenGroupFlagMatchesRequestedName() {
-		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
+	/**
+	 * @dataProvider isGroupDataProvider
+	 */
+	public function testShouldDetectTheRequestedGroup( $argv, $group_name, $expected ) {
+		$this->setArgv( $argv );
 
-		$this->assertTrue( Subject::isGroup( 'AdminOnly' ) );
+		$this->assertSame( $expected, Subject::isGroup( $group_name ) );
 	}
 
-	public function testShouldReturnFalseWhenGroupFlagNameDiffers() {
-		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
-
-		$this->assertFalse( Subject::isGroup( 'Multisite' ) );
-	}
-
-	public function testShouldReturnFalseWhenNoGroupFlagPresent() {
-		$this->setArgv( [ 'x', 'integration' ] );
-
-		$this->assertFalse( Subject::isGroup( 'AdminOnly' ) );
-	}
-
-	public function testShouldReturnFalseWhenGroupFlagHasNoNameAfterIt() {
-		$this->setArgv( [ 'x', 'integration', '--group' ] );
-
-		$this->assertFalse( Subject::isGroup( 'AdminOnly' ) );
+	public function isGroupDataProvider() {
+		return $this->getTestData( __DIR__, 'isGroup' );
 	}
 }

--- a/Tests/Unit/BootstrapManager/isGroup.php
+++ b/Tests/Unit/BootstrapManager/isGroup.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+use WPMedia\PHPUnit\BootstrapManager as Subject;
+
+/**
+ * @covers WPMedia\PHPUnit\BootstrapManager::isGroup
+ * @group  BootstrapManager
+ */
+class Test_IsGroup extends TestCase {
+
+	public function testShouldReturnTrueWhenGroupFlagMatchesRequestedName() {
+		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
+
+		$this->assertTrue( Subject::isGroup( 'AdminOnly' ) );
+	}
+
+	public function testShouldReturnFalseWhenGroupFlagNameDiffers() {
+		$this->setArgv( [ 'x', 'integration', '--group', 'AdminOnly' ] );
+
+		$this->assertFalse( Subject::isGroup( 'Multisite' ) );
+	}
+
+	public function testShouldReturnFalseWhenNoGroupFlagPresent() {
+		$this->setArgv( [ 'x', 'integration' ] );
+
+		$this->assertFalse( Subject::isGroup( 'AdminOnly' ) );
+	}
+
+	public function testShouldReturnFalseWhenGroupFlagHasNoNameAfterIt() {
+		$this->setArgv( [ 'x', 'integration', '--group' ] );
+
+		$this->assertFalse( Subject::isGroup( 'AdminOnly' ) );
+	}
+}

--- a/Tests/Unit/BootstrapManager/removeCliArg.php
+++ b/Tests/Unit/BootstrapManager/removeCliArg.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
+
+/**
+ * @covers WPMedia\PHPUnit\BootstrapManager::removeCliArg
+ * @group  BootstrapManager
+ */
+class Test_RemoveCliArg extends TestCase {
+
+	public function testShouldRemoveMatchingArgFromArgv() {
+		$this->setArgv( [ 'x', 'unit', 'path=Tests/Foo', '--filter', 'bar' ] );
+
+		$this->invoke( 'removeCliArg', [ 'path' ] );
+
+		// The element is unset in place; remaining keys are left untouched (not reindexed).
+		$this->assertArrayNotHasKey( 2, $_SERVER['argv'] );
+		$this->assertSame(
+			[ 0 => 'x', 1 => 'unit', 3 => '--filter', 4 => 'bar' ],
+			$_SERVER['argv']
+		);
+	}
+
+	public function testShouldLeaveArgvUnchangedWhenArgAbsent() {
+		$this->setArgv( [ 'x', 'unit', '--filter', 'bar' ] );
+
+		$this->invoke( 'removeCliArg', [ 'path' ] );
+
+		$this->assertSame( [ 'x', 'unit', '--filter', 'bar' ], $_SERVER['argv'] );
+	}
+}

--- a/Tests/Unit/BootstrapManager/removeCliArg.php
+++ b/Tests/Unit/BootstrapManager/removeCliArg.php
@@ -8,24 +8,18 @@ namespace WPMedia\PHPUnit\Tests\Unit\BootstrapManager;
  */
 class Test_RemoveCliArg extends TestCase {
 
-	public function testShouldRemoveMatchingArgFromArgv() {
-		$this->setArgv( [ 'x', 'unit', 'path=Tests/Foo', '--filter', 'bar' ] );
+	/**
+	 * @dataProvider removeCliArgDataProvider
+	 */
+	public function testShouldRemoveTheMatchingArg( $argv, $key, $expected ) {
+		$this->setArgv( $argv );
 
-		$this->invoke( 'removeCliArg', [ 'path' ] );
+		$this->invoke( 'removeCliArg', [ $key ] );
 
-		// The element is unset in place; remaining keys are left untouched (not reindexed).
-		$this->assertArrayNotHasKey( 2, $_SERVER['argv'] );
-		$this->assertSame(
-			[ 0 => 'x', 1 => 'unit', 3 => '--filter', 4 => 'bar' ],
-			$_SERVER['argv']
-		);
+		$this->assertSame( $expected, $_SERVER['argv'] );
 	}
 
-	public function testShouldLeaveArgvUnchangedWhenArgAbsent() {
-		$this->setArgv( [ 'x', 'unit', '--filter', 'bar' ] );
-
-		$this->invoke( 'removeCliArg', [ 'path' ] );
-
-		$this->assertSame( [ 'x', 'unit', '--filter', 'bar' ], $_SERVER['argv'] );
+	public function removeCliArgDataProvider() {
+		return $this->getTestData( __DIR__, 'removeCliArg' );
 	}
 }


### PR DESCRIPTION
## What & why

The package's own suite bootstraps through `Tests/{Unit,Integration}/init-tests.php`, which defines `WPMEDIA_PHPUNIT_ROOT_DIR` / `WPMEDIA_PHPUNIT_ROOT_TEST_DIR` directly and requires `src/{Unit,Integration}/bootstrap.php` — **bypassing the `wpmedia-phpunit` bin and most of `BootstrapManager`**. As a result the consumer-facing argv parsing had no coverage: a regression in it would ship with a green suite. The consumer entry point was also undocumented in the README.

## Changes

- **Tests** — add `Tests/Unit/BootstrapManager/` covering `getArg`, `removeCliArg`, `getRootDir`, `isGroup`, and `getConfigArgv` (18 tests), following the existing one-class-per-method convention with a per-group abstract `TestCase.php` that snapshots/restores `$_SERVER['argv']`/`argc`. Notable: verifies consumer args (`path=`, `WPMEDIA_PHPUNIT_ROOT_DIR=`) are stripped while real PHPUnit args pass through. Kept **out** of the `phpcs.xml.dist` scope, consistent with the other per-method test files (they trip the same `$_SERVER['argv']` sanitization / per-method-doc-comment rules).
- **README** — add "Running Your Repo's Tests" documenting `vendor/bin/wpmedia-phpunit unit|integration` and the `WPMEDIA_PHPUNIT_ROOT_DIR=` / `path=` / `--group` arguments (incl. `AdminOnly`→`WP_ADMIN`, `Multisite`→`MULTISITE`).
- **CLAUDE.md** — add an Architecture section (entry point, bootstraps, public API surface, `--group` side effects, test layout) plus the self-test caveat.

## Verification

- Full unit suite green: **119 tests, 327 assertions** (up from 101 tests) on PHP 8.2.
- Full PHPStan clean (`Tests/` is in its analysis paths).
- No production code changed — tests + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)