### PR TITLE
Closes #52: Make Unit/Integration bootstraps self-locating

### DIFF
--- a/src/Integration/bootstrap.php
+++ b/src/Integration/bootstrap.php
@@ -6,6 +6,13 @@ use WPMedia\PHPUnit\BootstrapManager;
 use function WPMedia\PHPUnit\init_test_suite;
 use Yoast\WPTestUtils\WPIntegration;
 
+if ( ! defined( 'WPMEDIA_PHPUNIT_ROOT_DIR' ) ) {
+	if ( ! class_exists( BootstrapManager::class ) ) {
+		require_once dirname( __DIR__ ) . '/BootstrapManager.php';
+	}
+	BootstrapManager::setupConstants( 'integration' );
+}
+
 require_once WPMEDIA_PHPUNIT_ROOT_DIR . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 require_once dirname( dirname( __FILE__ ) ) . '/bootstrap-functions.php';
 init_test_suite();

--- a/src/Unit/bootstrap.php
+++ b/src/Unit/bootstrap.php
@@ -4,6 +4,13 @@ namespace WPMedia\PHPUnit\Unit;
 
 use function WPMedia\PHPUnit\init_test_suite;
 
+if ( ! defined( 'WPMEDIA_PHPUNIT_ROOT_DIR' ) ) {
+	if ( ! class_exists( \WPMedia\PHPUnit\BootstrapManager::class ) ) {
+		require_once dirname( __DIR__ ) . '/BootstrapManager.php';
+	}
+	\WPMedia\PHPUnit\BootstrapManager::setupConstants( 'unit' );
+}
+
 require_once WPMEDIA_PHPUNIT_ROOT_DIR . '/vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once dirname( dirname( __FILE__ ) ) . '/bootstrap-functions.php';
 init_test_suite();


### PR DESCRIPTION
> 🤖 AI-generated — created by an automated pipeline. Review before acting on this.

Closes #52

## Summary

PHPUnit re-runs the configured bootstrap file standalone in isolated child processes (`@runInSeparateProcess`), where the `wpmedia-phpunit` bin never runs and `WPMEDIA_PHPUNIT_ROOT_DIR` / `WPMEDIA_PHPUNIT_ROOT_TEST_DIR` are never defined, causing a fatal "Undefined constant" error. This fix makes both bootstraps self-locating: they now guard-invoke `BootstrapManager::setupConstants()` at startup to self-derive the constants when absent, eliminating the need for consumers to maintain per-plugin `Tests/{Unit,Integration}/init-tests.php` shims whose only job was to pre-define these two constants.

## What was done

- Added a self-locating guard block to the top of both `src/Unit/bootstrap.php` and `src/Integration/bootstrap.php` (before the existing requires).
- The block mirrors the `wpmedia-phpunit` bin's pattern: guarded `class_exists()` check, `require_once` the `BootstrapManager` by relative path, then invoke `setupConstants($suite)`.
- The guard (`if ( ! defined() )`) ensures idempotence: when the bin pre-defines the constants in the parent process, or when the package's own self-test pre-defines them via `init-tests.php`, the block short-circuits and avoids a double-define warning (which becomes an exception under `convertWarningsToExceptions`).

## How to test

1. **Package's own test regression:** `composer test-unit` and `composer test-integration` both remain green (119 and 29 tests respectively), confirming the guard short-circuits correctly and `convertWarningsToExceptions` does not trip.
2. **PHPStan clean:** `composer phpstan` passes against the existing baseline (no new issues introduced).
3. **Isolated child (`@runInSeparateProcess`):** A consumer can now delete their `Tests/{Unit,Integration}/init-tests.php` shims, point phpunit's `bootstrap=` directly at `vendor/wp-media/phpunit/src/Unit/bootstrap.php` (or Integration), and run suites with isolated tests — the constants self-derive and no "Undefined constant" fatal occurs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Affected Features & Quality Assurance Scope

- Bootstrap initialization path for isolated test processes.
- Unit and integration test suites (both library self-tests and downstream consumers).

## Technical description

The root cause is architectural: `src/Unit/bootstrap.php` and `src/Integration/bootstrap.php` **use** the two constants but never **define** them — they assume a caller already did. This holds when invoked through the `wpmedia-phpunit` bin (which calls `BootstrapManager::setupConstants()` in the parent), but fails when PHPUnit re-executes the bootstrap file standalone in an isolated child process where the bin never ran.

The fix is a root-cause repair, not a workaround: add the same guarded setup block to the bootstraps themselves. Since the autoloader is not yet registered at the top of the bootstrap (it is only required later in `init_test_suite()`), we mirror the bin's approach: guard with `class_exists()`, then `require_once` the `BootstrapManager` by relative path (`dirname(__DIR__)` → `src/`), then call `setupConstants($suite)`. The `if ( ! defined() )` guard is load-bearing for the package's own self-test, which uses `convertWarningsToExceptions="true"` and pre-defines the constants via `Tests/{Unit,Integration}/init-tests.php` — a re-`define()` would emit a warning and become a fatal.

The derivation itself is unchanged: `BootstrapManager::getRootDir(false)` walks four levels up from `src/` to the consumer root (verified against the existing `getRootDir.php` test case), and `setupConstants()` defaults the test directory to `WPMEDIA_PHPUNIT_ROOT_DIR . '/Tests/' . ucfirst($suite)` when no `path=` override is present (the isolated-child case, where argv carries only PHPUnit's own args).

## New dependencies

None.

## Risks

None identified. The fix is guarded and mirrors the well-tested bin pattern; it only adds logic to an already-defined block in both bootstraps.

## Notes

**Intentional scope exclusions:**

- The package's own `Tests/{Unit,Integration}/init-tests.php` are **not** deleted. They must stay: the package is not installed under `vendor/`, so `getRootDir(false)`'s four-levels-up walk would resolve outside the repo and break the self-test (the documented "self-test caveat" in CLAUDE.md).
- The `wpmedia-phpunit` bin is unchanged.
- The secondary suggestion (adding a `WPMEDIA_PHPUNIT_SRC` env var or composer `extra` config to scope code-coverage) is a separate concern and deferred as a potential follow-up (#30 scope). It is not trivially coupled to this deliverable.

Contributes to #30 (reduce per-plugin boilerplate).